### PR TITLE
fix: move pids_limit into deploy.resources.limits.pids for Compose v2

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -75,9 +75,9 @@ services:
         limits:
           memory: ${RUNNER_MEMORY:-8g}
           cpus: "${RUNNER_CPUS:-4}"
+          pids: ${RUNNER_PIDS:-2048}
         reservations:
           memory: 1g
-    pids_limit: ${RUNNER_PIDS:-2048}
     ulimits:
       nofile:
         soft: 4096


### PR DESCRIPTION
## Summary
- Moves `pids_limit` from service-level key (line 80) into `deploy.resources.limits.pids` to fix Docker Compose v2 rejection
- This fix was supposed to be in v1.0.1 but was dropped during the PR #2 merge

## Context
Docker Compose v2 normalizes `pids_limit` into `deploy.resources.limits.pids`. Having both a `deploy.resources.limits` block and a service-level `pids_limit` causes:
```
services.runner: can't set distinct values on 'pids_limit' and 'deploy.resources.limits.pids': invalid compose project
```

Fixes #3

## Test plan
- [ ] `docker compose -f infra/docker-compose.yml config` succeeds without errors on Compose v2
