### PR TITLE
fix: add init:true to proxy to fix PID 1 healthcheck failure

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -13,6 +13,7 @@ services:
   proxy:
     image: ${PROXY_IMAGE:-ubuntu/squid:latest}
     container_name: ${RUNNER_NAME:-runsecure}-proxy
+    init: true
     restart: "no"
     volumes:
       - ./squid/runtime.conf:/etc/squid/squid.conf:ro

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
       context: ../../infra/squid
       dockerfile: Dockerfile
     container_name: runsecure-test-proxy
+    init: true
     volumes:
       - ${SQUID_CONF:-../../infra/squid/base.conf}:/etc/squid/squid.conf:ro
     networks:


### PR DESCRIPTION
## Summary
- Squid runs as PID 1 in the container, writes `1` to PID file
- `squid -k check` rejects PID 1: `FATAL: Bad PID file contains unreasonably small PID value: 1`
- Adding `init: true` injects tini as PID 1, squid gets PID 2+, healthcheck passes

## Verified
```
# Without init — FAILS
$ docker exec proxy squid -k check
FATAL: Bad PID file contains unreasonably small PID value: 1

# With init — PASSES
$ docker run --init ... && docker exec proxy squid -k check
exit: 0
```

Applied to both `infra/docker-compose.yml` and `tests/integration/docker-compose.test.yml`.

## Test plan
- [x] `docker run --init` + `squid -k check` returns exit 0
- [ ] `./tests/integration/run-integration-tests.sh` passes
