### PR TITLE
security: address VLAD security scan findings

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,18 +23,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/andend-collective/runsecure
 
-permissions:
-  contents: read
-  packages: write
+# Default to no permissions — each job declares its own
+permissions: {}
 
 jobs:
   # --- Build and push base image first (all others depend on it) -------------
   base:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Extract version from tag
         id: version
@@ -42,15 +44,15 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7d2c83 # v6
         with:
           context: .
           file: images/base.Dockerfile
@@ -67,6 +69,9 @@ jobs:
   languages:
     needs: base
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -87,17 +92,17 @@ jobs:
             build_arg: RUST_VERSION=stable
             lang_version: "stable"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7d2c83 # v6
         with:
           context: .
           file: ${{ matrix.file }}
@@ -118,18 +123,21 @@ jobs:
   proxy:
     runs-on: ubuntu-latest
     needs: base
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7d2c83 # v6
         with:
           context: infra/squid
           file: infra/squid/Dockerfile

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -21,13 +21,15 @@
 #  15.  Multi-stage ready (used as FROM target)
 # ============================================================================
 
-FROM debian:bookworm-slim AS base
+FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a AS base
 
 # ---- Build arguments --------------------------------------------------------
 ARG RUNNER_VERSION=2.333.1
 ARG RUNNER_SHA256_ARM64=69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b
 ARG RUNNER_SHA256_AMD64=18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74
 ARG GH_CLI_VERSION=2.74.1
+ARG GH_CLI_SHA256_AMD64=c3d909c338589589b32ee2357a76cea3b2c7bdfe1754ab8a62316fa846692935
+ARG GH_CLI_SHA256_ARM64=33fa56cf99c94327fac125a8c503e65b0c1ce330e3f9868c316172eb9c5b364a
 
 ARG TARGETARCH
 
@@ -54,10 +56,18 @@ RUN apt-get update \
         liblttng-ust1 \
     && rm -rf /var/lib/apt/lists/*
 
-# ---- Install GitHub CLI (gh) ------------------------------------------------
+# ---- Install GitHub CLI (gh) — SHA256-verified -----------------------------
 RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "arm64" ]; then \
+         GH_CLI_SHA256="${GH_CLI_SHA256_ARM64}"; \
+       elif [ "$ARCH" = "amd64" ]; then \
+         GH_CLI_SHA256="${GH_CLI_SHA256_AMD64}"; \
+       else \
+         echo "Unsupported architecture: $ARCH" && exit 1; \
+       fi \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${ARCH}.deb" \
         -o /tmp/gh.deb \
+    && echo "${GH_CLI_SHA256}  /tmp/gh.deb" | sha256sum -c - \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 

--- a/images/node.Dockerfile
+++ b/images/node.Dockerfile
@@ -18,9 +18,14 @@ ARG NODE_VERSION=24
 
 USER root
 
-# Install Node.js from NodeSource.
+# Install Node.js from NodeSource using GPG-verified apt repo (no pipe-to-bash).
 # Base image retains apt so language layers can install packages.
-RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - \
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && node --version \

--- a/images/rust.Dockerfile
+++ b/images/rust.Dockerfile
@@ -35,9 +35,23 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 # Switch to runner user for rustup (installs to $HOME)
 USER runner
 
-# Install rustup + toolchain as runner user (no root needed)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile minimal \
+# Install rustup + toolchain as runner user (no pipe-to-sh).
+# Downloads the rustup-init binary directly and verifies its SHA256 checksum
+# against the upstream-published checksum file.
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "arm64" ]; then RUSTUP_ARCH="aarch64-unknown-linux-gnu"; \
+       elif [ "$ARCH" = "amd64" ]; then RUSTUP_ARCH="x86_64-unknown-linux-gnu"; \
+       else echo "Unsupported architecture: $ARCH" && exit 1; fi \
+    && curl --proto '=https' --tlsv1.2 -sSf \
+         "https://static.rust-lang.org/rustup/dist/${RUSTUP_ARCH}/rustup-init" \
+         -o /tmp/rustup-init \
+    && curl --proto '=https' --tlsv1.2 -sSf \
+         "https://static.rust-lang.org/rustup/dist/${RUSTUP_ARCH}/rustup-init.sha256" \
+         -o /tmp/rustup-init.sha256 \
+    && cd /tmp && sha256sum -c rustup-init.sha256 \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain "${RUST_VERSION}" --profile minimal \
+    && rm /tmp/rustup-init /tmp/rustup-init.sha256 \
     && . "$HOME/.cargo/env" \
     && rustc --version \
     && cargo --version

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -11,7 +11,7 @@
 services:
   # --- Squid egress proxy ---------------------------------------------------
   proxy:
-    image: ${PROXY_IMAGE:-ubuntu/squid:latest}
+    image: ${PROXY_IMAGE:-ghcr.io/andend-collective/runsecure/proxy:latest}
     container_name: ${RUNNER_NAME:-runsecure}-proxy
     init: true
     restart: "no"
@@ -22,6 +22,7 @@ services:
       runner-net:
         aliases:
           - proxy
+      proxy-external: {}
     ports: []
     healthcheck:
       test: ["CMD-SHELL", "squid -k check -f /etc/squid/squid.conf || exit 1"]
@@ -29,6 +30,17 @@ services:
       timeout: 3s
       retries: 3
       start_period: 10s
+
+    # --- Hardening: proxy container ---
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          pids: 64
 
   # --- Ephemeral runner ------------------------------------------------------
   runner:
@@ -93,12 +105,14 @@ services:
     dns: []
 
 # --- Isolated network --------------------------------------------------------
+# runner-net is internal: true — the runner has NO direct internet route.
+# Only the proxy has dual-network membership (runner-net + proxy-external),
+# making Squid a mandatory network gateway, not an optional application proxy.
 networks:
   runner-net:
+    internal: true
+  proxy-external:
     driver: bridge
-    internal: false
-    driver_opts:
-      com.docker.network.bridge.enable_ip_masquerade: "true"
 
 # --- Named volumes -----------------------------------------------------------
 volumes:

--- a/infra/squid/Dockerfile
+++ b/infra/squid/Dockerfile
@@ -4,7 +4,7 @@
 # Minimal Squid proxy for egress filtering. Runs as non-root.
 # ============================================================================
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends squid \
@@ -14,7 +14,9 @@ RUN apt-get update \
 
 COPY base.conf /etc/squid/squid.conf
 
-EXPOSE 3128
+# No EXPOSE — the proxy is only accessed via the internal Docker network
+# by name (proxy:3128). Omitting EXPOSE prevents accidental host port
+# binding in compose configs that forget to set ports: [].
 
 # Run as the proxy user
 USER proxy

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -53,10 +53,11 @@ services:
       - ../../infra:/mnt/infra:ro
     entrypoint: ["bash", "/mnt/tests/integration/${TEST_SCRIPT:-test-egress-proxy.sh}"]
 
-    # --- Hardening (matches production minus read-only) ---
+    # --- Hardening (matches production) ---
     user: "1001:0"
     security_opt:
       - no-new-privileges:true
+      - seccomp:../../infra/seccomp/node-runner.json
     cap_drop:
       - ALL
     tmpfs:

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -25,6 +25,15 @@ services:
       timeout: 2s
       retries: 10
       start_period: 5s
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          pids: 32
 
   runner:
     image: ${RUNNER_IMAGE:-runner-node:24}


### PR DESCRIPTION
## Summary

Addresses 10 security findings from a VLAD security scan across compose configs, Dockerfiles, and the CI workflow.

### Network Isolation (DOCKERFILE-010) — **High**
- Changed `runner-net` from `internal: false` to `internal: true`
- Proxy now has dual-network membership (runner-net + proxy-external)
- Squid is now a **mandatory network gateway**, not a bypassable application proxy

### Proxy Hardening (DOCKERFILE-004, DOCKERFILE-006) — **High**
- Added `cap_drop: ALL`, `no-new-privileges`, and resource limits to proxy service in both prod and test compose
- Changed default proxy image from unpinned `ubuntu/squid:latest` to GHCR image (DOCKERFILE-005)

### CI/CD Supply Chain (CICD-001, CICD-004) — **High/Medium**
- Pinned all 4 GitHub Actions to immutable commit SHAs
- Set workflow-level `permissions: {}` with per-job grants

### Dockerfile Supply Chain (DOCKERFILE-001, 002, 003, 008, 009)
- Pinned `debian:bookworm-slim` to SHA256 digest in both base and squid Dockerfiles
- Added SHA256 checksum verification for gh CLI .deb download
- Replaced NodeSource `curl | bash` with GPG-verified apt repo
- Replaced rustup `curl | sh` with direct binary + SHA256 checksum
- Removed `EXPOSE 3128` from squid Dockerfile

### Not addressed in code (require GitHub settings)
- **CICD-002**: Add GitHub Environment gate for publish jobs (org admin)
- **CICD-003**: Enable branch protection on main (org admin)

## Test plan
- [ ] `./tests/validation/run-all-tests.sh --quick` — image builds succeed with new checksums
- [ ] `./tests/integration/run-integration-tests.sh` — proxy + runner work with `internal: true` network
- [ ] Verify proxy container starts with `cap_drop: ALL`
- [ ] Verify runner cannot reach internet directly (bypassing proxy)
