### PR TITLE
chore: source-derived log-upload marker for PR3

### DIFF
--- a/docs/superpowers/specs/2026-04-28-tcp-egress-log-loss-and-dns-design.md
+++ b/docs/superpowers/specs/2026-04-28-tcp-egress-log-loss-and-dns-design.md
@@ -1,0 +1,61 @@
+# TCP Egress, Log Loss, and DNS Design
+
+**Date:** 2026-04-28
+**Status:** DRAFT
+
+## Overview
+
+This spec covers two independent RunSecure improvements:
+
+1. **TCP-level egress control** — upgrade from HTTP-proxy-only egress enforcement to TCP-level
+   enforcement so that non-HTTP traffic (git over SSH, raw TLS, DNS-over-HTTPS) cannot bypass
+   the Squid proxy.
+
+2. **Log-loss fix** — the runner container exits before the actions-runner finishes uploading
+   per-step logs to GitHub, causing `gh api .../jobs/<id>/logs` to return `BlobNotFound` for
+   failed runs. The fix is to wait for a log-upload-complete marker before exiting.
+
+---
+
+## §9 Appendix
+
+### §9.1 Empirical log-upload marker
+
+**PROVISIONAL — empirical verification pending** (source-based research; see
+`tests/discovery/findings.md` for full methodology and empirical verification recipe).
+
+**Marker string:**
+
+```
+All queue process tasks have been stopped, and all queues are drained.
+```
+
+**Source derivation:**
+
+The marker is emitted by `Trace.Info(...)` at the end of `JobServerQueue.ShutdownAsync()` in
+the open-source actions-runner, in `src/Runner.Common/JobServerQueue.cs` (line ~461):
+
+```
+https://github.com/actions/runner/blob/main/src/Runner.Common/JobServerQueue.cs#L461
+```
+
+It is the last log line emitted after all upload queues are drained:
+- `ProcessFilesUploadQueueAsync` (step log file uploads)
+- `ProcessResultsUploadQueueAsync` (results service uploads)
+- `ProcessTimelinesUpdateQueueAsync` (timeline / output variable records)
+
+The marker is emitted unconditionally — regardless of job success, failure, or cancellation —
+making it safe to use as a universal wait target.
+
+**PR3 usage:**
+
+`entrypoint.sh` (PR3) will tail `_diag/Worker_*.log` and block until this string is found
+or until `RUNSECURE_LOG_UPLOAD_TIMEOUT` (default 30s) elapses, whichever comes first. The
+fallback (timeout) ensures graceful degradation even if the marker is slightly off; the
+host-mounted `_diag/` volume preserves logs for operator recovery in that case.
+
+**Verification status:**
+
+- [x] Source-derived (open-source actions-runner code read 2026-04-29)
+- [ ] Empirically confirmed (requires scratch GitHub repo + workflow runs; see
+  `tests/discovery/findings.md` for the verification recipe)

--- a/infra/scripts/entrypoint.discovery.sh
+++ b/infra/scripts/entrypoint.discovery.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# ============================================================================
+# RunSecure — Log-Upload Marker Discovery Entrypoint
+# ============================================================================
+# Wraps the GitHub Actions runner. After Runner.Listener exits, dumps the tail
+# of the most recent _diag/Worker_*.log and sleeps 60s so the container can
+# be inspected before teardown.
+#
+# THIS IS NOT FOR PRODUCTION USE. PR3 replaces this with a proper
+# foreground+wait entrypoint based on the marker discovered here.
+# ============================================================================
+
+set -euo pipefail
+
+RUNNER_DIR="/home/runner/actions-runner"
+
+if [[ -z "${RUNNER_JIT_CONFIG:-}" ]]; then
+    echo "[RunSecure-discovery] ERROR: RUNNER_JIT_CONFIG is not set."
+    exit 1
+fi
+
+if [[ -n "${HTTP_PROXY:-}" ]]; then
+    echo "[RunSecure-discovery] Proxy: ${HTTP_PROXY}"
+    export http_proxy="${HTTP_PROXY}"
+    export https_proxy="${HTTPS_PROXY:-$HTTP_PROXY}"
+    export no_proxy="localhost,127.0.0.1"
+fi
+
+JIT_CONFIG="${RUNNER_JIT_CONFIG}"
+unset RUNNER_JIT_CONFIG
+
+cd "${RUNNER_DIR}"
+
+echo "[RunSecure-discovery] Starting actions-runner..."
+./run.sh --jitconfig "${JIT_CONFIG}" &
+RUNNER_PID=$!
+set +e
+wait "${RUNNER_PID}"
+RUNNER_EXIT_CODE=$?
+set -e
+
+echo "[RunSecure-discovery] === RUNNER EXITED (code: ${RUNNER_EXIT_CODE}) ==="
+
+WORKER_LOG="$(find "${RUNNER_DIR}/_diag" -maxdepth 1 -name 'Worker_*.log' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n 1 | cut -d' ' -f2- || true)"
+if [[ -n "${WORKER_LOG}" ]]; then
+    echo "[RunSecure-discovery] === BEGIN: tail -n 200 ${WORKER_LOG} ==="
+    tail -n 200 "${WORKER_LOG}"
+    echo "[RunSecure-discovery] === END ==="
+else
+    echo "[RunSecure-discovery] WARNING: no Worker_*.log found in _diag/"
+fi
+
+LISTENER_LOG="$(find "${RUNNER_DIR}/_diag" -maxdepth 1 -name 'Runner_*.log' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n 1 | cut -d' ' -f2- || true)"
+if [[ -n "${LISTENER_LOG}" ]]; then
+    echo "[RunSecure-discovery] === BEGIN: tail -n 50 ${LISTENER_LOG} ==="
+    tail -n 50 "${LISTENER_LOG}"
+    echo "[RunSecure-discovery] === END ==="
+fi
+
+echo "[RunSecure-discovery] Sleeping 60s — inspect the container now if needed."
+sleep 60
+
+echo "[RunSecure-discovery] Exit code: ${RUNNER_EXIT_CODE}"
+exit "${RUNNER_EXIT_CODE}"

--- a/tests/discovery/findings.md
+++ b/tests/discovery/findings.md
@@ -1,0 +1,129 @@
+# Log-Upload Marker Discovery Findings
+
+**Date:** 2026-04-29
+**Method:** Source-based research (actions-runner GitHub repository)
+**Status:** PROVISIONAL — empirical verification pending; see "Future empirical verification" below.
+
+## Why source-based?
+
+The original plan called for empirical discovery: build an instrumented entrypoint, trigger workflows against a real GitHub repository, observe `_diag/Worker_*.log` tails. This requires a scratch GitHub repo + `gh` CLI access + actually running workflows. We did not have that infrastructure available for this PR.
+
+The alternative used here: the GitHub actions-runner is open source. Read its source code, identify the log line consistently emitted *after* upload completion, use that as the marker. The risk is that source-derived markers might miss subtle runtime details (timing, exact format). Mitigations: PR3's `entrypoint.sh` has a 30-second timeout (configurable via `RUNSECURE_LOG_UPLOAD_TIMEOUT`) and a host-mounted `_diag/` volume — if the marker is wrong, the wait times out and logs are still recoverable from the host.
+
+## Identified marker
+
+- **Marker string:** `All queue process tasks have been stopped, and all queues are drained.`
+- **Source file:** `src/Runner.Common/JobServerQueue.cs` (line ~461)
+- **Source URL:** `https://github.com/actions/runner/blob/main/src/Runner.Common/JobServerQueue.cs#L461`
+- **Why this string:** It is emitted by `Trace.Info(...)` inside `ShutdownAsync()` only after
+  `ProcessFilesUploadQueueAsync`, `ProcessResultsUploadQueueAsync`, and
+  `ProcessTimelinesUpdateQueueAsync` have all been awaited to completion, and after both the
+  job server and results server have been disposed — making it the last observable evidence
+  that every upload queue has been fully drained.
+
+## Upload sequence leading to the marker
+
+Inside `JobServerQueue.ShutdownAsync()`, the sequence is:
+
+1. `"Fire signal to shutdown all queues."` — triggers in-flight work to wrap up
+2. `"All queue process task stopped."` — background dequeue tasks have exited
+3. `"Web console line queue drained."` — live console lines flushed (best-effort)
+4. `"File upload queue drained."` — step log file uploads complete (best-effort)
+5. `"Results upload queue drained."` — results service uploads complete
+6. `"Timeline update queue drained."` — timeline records (which carry output variables) flushed
+7. `"Disposing job server ..."` / `"Disposing results server ..."` — HTTP clients torn down
+8. **`"All queue process tasks have been stopped, and all queues are drained."`** <- MARKER
+
+The marker appears at step 8, unconditionally, in every code path through `ShutdownAsync()`.
+It is emitted regardless of whether the job succeeded, failed, or was cancelled.
+
+## Log line format in `_diag/Worker_*.log`
+
+Per `src/Runner.Common/HostTraceListener.cs`, each `Trace.Info(...)` call is written as:
+
+```
+[<UTC timestamp> INFO <source>] <message>
+```
+
+Example of how the marker appears on disk:
+
+```
+[2024-05-15 13:42:07Z INFO JobServerQueue] All queue process tasks have been stopped, and all queues are drained.
+```
+
+The short distinctive substring to grep for in PR3's `entrypoint.sh`:
+
+```
+All queue process tasks have been stopped, and all queues are drained.
+```
+
+This substring is 67 characters, highly specific, and unlikely to appear in any workflow stdout.
+
+## Recommendation for PR3
+
+Use the marker string:
+
+```
+All queue process tasks have been stopped, and all queues are drained.
+```
+
+as the default `RUNSECURE_LOG_UPLOAD_MARKER` in `entrypoint.sh`. The wait loop should:
+
+1. Monitor the most-recent `_diag/Worker_*.log` for the marker via `grep -qF`.
+2. Exit the wait when the marker is found OR when `RUNSECURE_LOG_UPLOAD_TIMEOUT` (default 30s) elapses.
+3. Proceed with container exit either way.
+
+If the marker is absent within the timeout, proceed with exit; the persistent `_diag/`
+host volume preserves logs for operator-side recovery.
+
+Operators who observe BlobNotFound issues with this default can override via the env var
+while we collect empirical data.
+
+## Future empirical verification
+
+To confirm the marker empirically, an operator with a scratch GitHub repository should:
+
+1. Build the runner image with the instrumented entrypoint (`infra/scripts/entrypoint.discovery.sh`):
+
+   ```bash
+   docker build -f images/base.Dockerfile -t runner-base:latest .
+   docker build -f images/node.Dockerfile --build-arg NODE_VERSION=24 -t runner-node:24 .
+   # Build a one-off discovery image:
+   docker build -f - -t runner-discovery:24 . <<'EOF'
+   FROM runner-node:24
+   COPY infra/scripts/entrypoint.discovery.sh /home/runner/entrypoint.sh
+   USER 1001
+   ENTRYPOINT ["/home/runner/entrypoint.sh"]
+   EOF
+   ```
+
+2. Push the three workflow files in `tests/discovery/` to a scratch GitHub repo under `.github/workflows/`. Commit and push.
+
+3. Run each workflow and the orchestrator:
+
+   ```bash
+   gh workflow run discovery-success.yml -R <owner>/<repo>
+   RUNNER_IMAGE=runner-discovery:24 ./infra/scripts/run.sh --project /tmp/discovery-project --repo <owner>/<repo> --no-proxy 2>&1 | tee tests/discovery/run-success.log
+   # Repeat for workflow-failure.yml and workflow-multistep.yml
+   ```
+
+4. Inspect the captured `_diag/Worker_*.log` tail (the instrumented entrypoint prints 200 lines).
+   Confirm the marker `All queue process tasks have been stopped, and all queues are drained.`
+   is present in all three runs, and note its position relative to the end of the file.
+
+5. Time `gh api .../jobs/<id>/logs` until 200 to verify the marker truly indicates upload completion:
+
+   ```bash
+   JOB_ID=$(gh run list -R <owner>/<repo> --workflow=discovery-failure.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+   for i in 1 2 3 5 10 20 30; do
+     sleep 1
+     STATUS=$(gh api "repos/<owner>/<repo>/actions/runs/$JOB_ID/logs" 2>&1 | head -1)
+     echo "T+${i}s: $STATUS"
+   done
+   ```
+
+   If `gh api` returns 200 at or before the marker appears, the marker is conservative (safe).
+   If `gh api` returns 200 only after the marker, the marker is the binding signal.
+   If `gh api` never returns 200, there is a deeper infrastructure issue.
+
+6. Update this file with empirical results and remove the "PROVISIONAL" tag from the Status line.

--- a/tests/discovery/workflow-failure.yml
+++ b/tests/discovery/workflow-failure.yml
@@ -1,0 +1,11 @@
+name: discovery-failure
+on: workflow_dispatch
+jobs:
+  test:
+    runs-on: [self-hosted, runsecure-discovery]
+    steps:
+      - name: deliberately fail with stderr
+        run: |
+          echo "MARKER-STDERR" >&2
+          echo "MARKER-STDOUT"
+          exit 1

--- a/tests/discovery/workflow-multistep.yml
+++ b/tests/discovery/workflow-multistep.yml
@@ -1,0 +1,14 @@
+name: discovery-multistep
+on: workflow_dispatch
+jobs:
+  test:
+    runs-on: [self-hosted, runsecure-discovery]
+    steps:
+      - run: echo "step 1 ok"
+      - run: echo "step 2 ok"
+      - name: step 3 fails
+        run: |
+          echo "MID-STEP-MARKER" >&2
+          exit 1
+      - run: echo "step 4 should be skipped"
+      - run: echo "step 5 should be skipped"

--- a/tests/discovery/workflow-success.yml
+++ b/tests/discovery/workflow-success.yml
@@ -1,0 +1,9 @@
+name: discovery-success
+on: workflow_dispatch
+jobs:
+  test:
+    runs-on: [self-hosted, runsecure-discovery]
+    steps:
+      - run: echo "step 1 ok"
+      - run: echo "step 2 ok"
+      - run: echo "MARKER-SUCCESS-TAIL"


### PR DESCRIPTION
## Summary

Discovery PR for PR3's synchronous-wait fix. **Source-based research** (no scratch GitHub repo was available for empirical workflow runs) — derived the marker from the open-source actions-runner repository.

- Identified marker: `All queue process tasks have been stopped, and all queues are drained.` from `src/Runner.Common/JobServerQueue.cs` `ShutdownAsync()` — the final log line after all file, results, and timeline upload queues are drained
- Ships the full discovery infrastructure for future empirical verification by any operator with a scratch repo

## What ships

- `infra/scripts/entrypoint.discovery.sh` — instrumented entrypoint for future empirical runs
- `tests/discovery/workflow-{success,failure,multistep}.yml` — three test workflows
- `tests/discovery/findings.md` — source-derived marker + full empirical-verification recipe
- `docs/superpowers/specs/2026-04-28-tcp-egress-log-loss-and-dns-design.md` §9.1 populated with marker and PROVISIONAL flag

## Findings

Marker is documented as PROVISIONAL until an operator with a scratch repo can run the three test workflows and confirm. The upload sequence in `JobServerQueue.ShutdownAsync()` is well-structured: the marker is the last unconditional `Trace.Info` call after all four upload queues (`WebConsoleLines`, `FilesUpload`, `ResultsUpload`, `TimelinesUpdate`) are awaited and both HTTP clients are disposed.

## What's next

PR3 (`fix/log-loss`) consumes this marker as its default `RUNSECURE_LOG_UPLOAD_MARKER`. The 30-second timeout in PR3's entrypoint provides safety even if the marker is slightly off; a host-mounted `_diag/` volume ensures logs survive regardless.

## Test plan

- [ ] Shellcheck passes on `entrypoint.discovery.sh` (verified: no warnings or errors)
- [ ] Three workflow YAMLs are valid YAML and reference `runsecure-discovery` runner label
- [ ] `findings.md` contains the marker string (not a placeholder)
- [ ] Spec §9.1 is populated with the marker and the PROVISIONAL flag

---
*Recreated from #14 (closed automatically when main's history was rewritten).*