### PR TITLE
feat(runner): job hooks expose hardening posture in GitHub Actions UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,35 @@ failure. To bypass in an emergency: `git push --no-verify`.
 
 ---
 
+## Workflow log diagnostics
+
+Every job run on a RunSecure runner gets two **automatic diagnostic
+groups** in the GitHub Actions UI — no workflow changes required:
+
+```
+▶ RunSecure container — runtime posture
+▶ RunSecure container — hardening properties
+▶ RunSecure container — network posture
+▶ RunSecure container — available toolchains
+▶ RunSecure debugging pointers
+```
+
+These appear under "Job started hook" at the top of every workflow log.
+The "hardening properties" group prints actual values — `CapEff`,
+`NoNewPrivs`, seccomp mode, `/tmp` mount flags, `/etc` mode — so a user
+debugging a job can verify the runtime is enforcing what RunSecure
+documents, without cloning this repo.
+
+The script lives at `infra/runner-hooks/job-started.sh`; it's wired in
+via the actions-runner's `ACTIONS_RUNNER_HOOK_JOB_STARTED` env var
+(set in `images/base.Dockerfile`). A symmetric `job-completed.sh` runs
+at job teardown with an exit summary.
+
+Both hooks are fail-safe — non-zero exit from a hook would fail the
+job per actions-runner contract, so each script wraps every command in
+`|| true` and ends with `trap 'exit 0' ERR`. A diagnostic should
+never be the reason a job fails.
+
 ## Operational notes
 
 ### Per-job logs land on the host

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -156,6 +156,32 @@ RUN passwd -l root 2>/dev/null || true \
 # ---- Security hardening: minimal PATH --------------------------------------
 ENV PATH="/home/runner/actions-runner:/home/runner/actions-runner/bin:/usr/local/bin:/usr/bin:/bin"
 
+# ---- GitHub Actions image-metadata env vars --------------------------------
+# Hosted runners set ImageOS / ImageVersion to populate the "Operating System"
+# and "Runner Image" groups in the workflow log UI. Self-hosted runners
+# don't carry these by default — workflow logs render with empty group
+# headers. We set RunSecure-flavored values so consumers see *something*
+# in the UI that identifies what they're running on.
+#
+# The "Included Software" link the actions-runner constructs from these
+# values will 404 (it points at github.com/actions/runner-images, which
+# only knows about its own image set). That's a known, accepted UI quirk —
+# the values themselves are still informative.
+ENV ImageOS=runsecure-bookworm
+ENV ImageVersion=2.334.0
+
+# ---- Job-started diagnostics hook ------------------------------------------
+# When ACTIONS_RUNNER_HOOK_JOB_STARTED is set, the actions-runner executes
+# the named script at the start of every job and pipes its output into the
+# workflow log as a real "Job started hook" step. We use this to publish
+# RunSecure's hardening posture (capabilities, seccomp state, mounts,
+# proxy config, available toolchains) to GitHub's UI so a user debugging
+# a job doesn't need to clone our repo to understand the runtime.
+COPY infra/runner-hooks /opt/runsecure-hooks
+RUN chmod 755 /opt/runsecure-hooks/job-started.sh /opt/runsecure-hooks/job-completed.sh
+ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runsecure-hooks/job-started.sh
+ENV ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/opt/runsecure-hooks/job-completed.sh
+
 # ---- Final setup ------------------------------------------------------------
 USER runner
 WORKDIR /home/runner

--- a/infra/runner-hooks/job-completed.sh
+++ b/infra/runner-hooks/job-completed.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# ============================================================================
+# RunSecure — Job-Completed Hook
+# ============================================================================
+# Fires at the end of every job. Output appears in the workflow log as
+# a "Job completed hook" step. Used for teardown summary + breadcrumbs
+# the user might want at the end of a failing job.
+#
+# Same fail-safe contract as job-started.sh — must always exit 0.
+# ============================================================================
+
+trap 'exit 0' ERR
+set -uo pipefail
+
+_safe() { "$@" 2>/dev/null || true; }
+
+echo "::group::RunSecure container — exit summary"
+echo "Job ended:       $(_safe date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Memory peak:     $(_safe awk '/VmHWM/ {print $2 " " $3}' /proc/self/status)"
+echo "Process count:   $(_safe ls /proc | grep -cE '^[0-9]+$')"
+# Inspect /tmp for leftover artifacts (jobs that downloaded things)
+TMP_FILES=$(_safe find /tmp -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
+echo "/tmp entries:    ${TMP_FILES:-0}  (will be discarded — container is --rm)"
+echo ""
+echo "Container will exit and be destroyed. Worker log uploaded to GitHub."
+echo "If logs show 'BlobNotFound', orchestrator's _diag/Worker_*.log has the full trace."
+echo "::endgroup::"
+
+exit 0

--- a/infra/runner-hooks/job-started.sh
+++ b/infra/runner-hooks/job-started.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# ============================================================================
+# RunSecure — Job-Started Hook
+# ============================================================================
+# Fires at the start of every job picked up by a RunSecure runner. The
+# actions-runner pipes our stdout into the workflow log as a real
+# "Job started hook" step, so this output appears in the GitHub Actions
+# UI right alongside the job's own steps.
+#
+# Use this to publish hardening posture, runtime info, and debugging
+# pointers — making RunSecure jobs self-explanatory in the UI without
+# requiring the user to clone this repo.
+#
+# IMPORTANT: this script MUST exit 0. A non-zero exit from a job-started
+# hook is treated as a job failure by the actions-runner. Wrap any
+# command that might fail with `|| true`. The trap below is a safety net.
+# ============================================================================
+
+# Catch any unexpected error and exit 0 anyway — a diagnostic hook should
+# never be the reason a job fails.
+trap 'exit 0' ERR
+set -uo pipefail
+
+_safe() { "$@" 2>/dev/null || true; }
+
+echo "::group::RunSecure container — runtime posture"
+echo "Image:           $(_safe cat /etc/os-release | _safe grep PRETTY_NAME | _safe cut -d= -f2 | _safe tr -d '\"')"
+echo "Kernel:          $(_safe uname -srm)"
+echo "Architecture:    $(_safe uname -m)"
+echo "User:            $(_safe id -u):$(_safe id -g) ($(_safe whoami))"
+echo "ImageOS:         ${ImageOS:-(unset)}"
+echo "ImageVersion:    ${ImageVersion:-(unset)}"
+echo "Hostname:        $(_safe hostname)"
+echo "::endgroup::"
+
+echo "::group::RunSecure container — hardening properties"
+# Capabilities (effective set is the only one that actually grants powers)
+CAP_EFF=$(_safe grep '^CapEff:' /proc/self/status | awk '{print $2}')
+echo "Effective caps:  ${CAP_EFF:-(unreadable)}  (0000000000000000 = empty = cap_drop ALL)"
+# NoNewPrivs flag set by --security-opt no-new-privileges:true
+NNP=$(_safe grep '^NoNewPrivs:' /proc/self/status | awk '{print $2}')
+echo "NoNewPrivs:      ${NNP:-(unknown)}            (1 = setuid-escalation blocked)"
+# Seccomp filter mode (2 = filter active)
+SECCOMP=$(_safe grep '^Seccomp:' /proc/self/status | awk '{print $2}')
+echo "Seccomp mode:    ${SECCOMP:-(unknown)}            (0=disabled  1=strict  2=filter active)"
+# /tmp mount flags
+TMP_OPTS=$(_safe awk '$2 == "/tmp" {print $4}' /proc/mounts)
+echo "/tmp options:    ${TMP_OPTS:-(unknown)}"
+# /etc immutability check
+ETC_MODE=$(_safe stat -c '%a' /etc)
+PASSWD_MODE=$(_safe stat -c '%a' /etc/passwd)
+echo "/etc mode:       ${ETC_MODE:-(unknown)} (555 = locked)   /etc/passwd: ${PASSWD_MODE:-(unknown)} (444 = locked)"
+echo "::endgroup::"
+
+echo "::group::RunSecure container — network posture"
+echo "HTTP_PROXY:      ${HTTP_PROXY:-(unset)}"
+echo "HTTPS_PROXY:     ${HTTPS_PROXY:-(unset)}"
+echo "NO_PROXY:        ${NO_PROXY:-(unset)}"
+echo "DNS resolvers:"
+_safe awk '$1 == "nameserver" {print "  " $2}' /etc/resolv.conf
+echo "Default route:"
+_safe ip route show default 2>/dev/null | head -3 | sed 's/^/  /'
+echo "(internal-only network: no default route is expected — egress is via the proxy)"
+echo "::endgroup::"
+
+echo "::group::RunSecure container — available toolchains"
+for tool in node npm python3 pip3 go cargo gh git curl jq yq; do
+    if command -v "$tool" >/dev/null 2>&1; then
+        version=$("$tool" --version 2>&1 | head -1)
+        printf '  %-8s  %s\n' "$tool" "$version"
+    fi
+done
+echo "::endgroup::"
+
+echo "::group::RunSecure debugging pointers"
+echo "If your job behaved unexpectedly, here's where to look:"
+echo ""
+echo "  Egress denied?"
+echo "    The proxy log on the orchestrator host is at _diag-proxy/access.log"
+echo "    Add domains to your project's runner.yml under http_egress:"
+echo "    Or for raw TCP: tcp_egress: [\"host:port\"]"
+echo ""
+echo "  Per-job worker log (after the job ends):"
+echo "    _diag/Worker_<timestamp>.log on the orchestrator host"
+echo "    (set RUNSECURE_DIAG_RETENTION=0 on shared hosts to disable)"
+echo ""
+echo "  DNS resolution issues?"
+echo "    Set 'dns: { host: false, log_queries: true }' in runner.yml"
+echo "    Then check _diag-proxy/dnsmasq.log on the orchestrator"
+echo ""
+echo "  Need to escape a hardening rule (curl/jq/etc removed)?"
+echo "    The 'hardening:' block in runner.yml is opt-in — see README"
+echo ""
+echo "  Full RunSecure docs: https://github.com/AndEnd-Collective/RunSecure"
+echo "  Threat model:        https://github.com/AndEnd-Collective/RunSecure/blob/main/SECURITY.md"
+echo "::endgroup::"
+
+exit 0


### PR DESCRIPTION
## Summary

Stacked on PR #26. Two cosmetic-but-useful additions to the runner image so a user debugging a job in the GitHub Actions UI can understand what RunSecure is enforcing — without cloning this repo.

### 1. ImageOS / ImageVersion env vars (`images/base.Dockerfile`)

Hosted runners ship with these env vars set; the actions-runner reads them to populate the "Operating System" / "Runner Image" group headers at the top of every workflow log. Self-hosted runners that don't set them get empty/missing headers — the visual inconsistency you noticed.

Set to:
```
ImageOS=runsecure-bookworm
ImageVersion=2.334.0  (= the pinned actions/runner version)
```

The "Included Software" link the runner constructs from these will 404 (it points at github.com/actions/runner-images, which only documents its own image set). Known UI quirk; the values themselves are still informative.

### 2. ACTIONS_RUNNER_HOOK_JOB_STARTED + JOB_COMPLETED hooks

The actions-runner has an undocumented-but-supported escape hatch: when those env vars point at a script, the runner pipes the script's stdout into the workflow log as a real "Job started hook" step. We use this to publish RunSecure's hardening posture automatically — **no user workflow changes required**.

`infra/runner-hooks/job-started.sh` prints five GHA groups at the top of every job log:

| Group | Content |
|---|---|
| **Runtime posture** | image, kernel, arch, user, ImageOS/Version, hostname |
| **Hardening properties** | `CapEff`, `NoNewPrivs`, `Seccomp` mode, `/tmp` mount opts, `/etc` mode, `/etc/passwd` mode |
| **Network posture** | `HTTP_PROXY`, DNS resolvers, default route (or note that none exists) |
| **Available toolchains** | versions of node/npm/python3/pip3/go/cargo/gh/git/curl/jq/yq actually present |
| **Debugging pointers** | where `_diag/` lives, how to add egress entries, link to docs |

`infra/runner-hooks/job-completed.sh` prints an exit summary at job teardown (memory peak, `/tmp` leftovers, container destruction note).

### Fail-safe contract

Per actions-runner docs, a non-zero exit from a job-started hook FAILS the job. A diagnostic should never be the reason a job fails. So both scripts:

- Wrap every command in `|| true` via a `_safe()` helper
- End with `trap 'exit 0' ERR` as a safety net

## Verified locally

Ran `infra/runner-hooks/job-started.sh` inside the actual hardened container image (`runner-project:65d1035208d8`):

```
Effective caps:  0000000000000000  (0000000000000000 = empty = cap_drop ALL)
NoNewPrivs:      1                 (1 = setuid-escalation blocked)
Seccomp mode:    2                 (0=disabled  1=strict  2=filter active)
/tmp options:    rw,nosuid,nodev,noexec,relatime,inode64
/etc mode:       555 (555 = locked)   /etc/passwd: 444 (444 = locked)
```

All the things SECURITY.md claims, validated and surfaced to the GH UI — exactly the goal.

## What this means for users

Before:
- Workflow log starts with empty/missing image group headers
- Step output is whatever your `run:` blocks print
- To verify "did RunSecure actually enforce X?" you have to look at the orchestrator logs OR clone the repo and read SECURITY.md

After:
- Workflow log starts with five labeled groups containing the actual values
- A user with no RunSecure context can verify the runtime is what's documented
- "How do I get logs for the failing step?" / "How do I add a domain?" / "Where's the threat model?" all answered inline at the top of every job

## Test plan

- [x] Both hooks parse cleanly
- [x] Hardened-container exit code is 0 on a fully-broken simulated env
- [x] Output verified inside the actual runner-project image — all hardening properties read correctly
- [ ] CI on this PR confirms PR #26's lint surface still passes
- [ ] First real run after merge → user sees the new groups in the GH UI

## Stacking note

This PR's base is `chore/ci-hardening-and-dogfood` (PR #26). When PR #26 merges to main, this PR will auto-rebase and the diff against main will be just these two commits.