### PR TITLE
fix(ci): language images must FROM base:<ver>-beta, not :<ver>

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -141,7 +141,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/base
-            BASE_TAG=${{ needs.base.outputs.version }}
+            BASE_TAG=${{ needs.base.outputs.version }}-beta
             ${{ matrix.build_arg }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ needs.base.outputs.version }}-beta-${{ matrix.lang_version }}


### PR DESCRIPTION
## Summary

One-line fix for the broken release path discovered while exercising v1.1.2.

The beta-first publish design (PR #27) only pushes `base:<ver>-beta` + `:nightly`. The bare `base:<ver>` doesn't exist until `promote-to-stable.yml` runs after acceptance. But the language matrix in `publish-images.yml` still passed `BASE_TAG=<ver>` to its docker build, which fails:

```
failed to resolve source metadata for ghcr.io/.../base:1.1.2: not found
```

(Reproduces in publish run [25268149248](https://github.com/AndEnd-Collective/RunSecure/actions/runs/25268149248) — `rust` failed at `FROM ${BASE_IMAGE}:${BASE_TAG}`, fail-fast cancelled the others.)

Fix: pass `BASE_TAG=<ver>-beta`. The resulting language image references the base by digest (not by tag), so the eventual promotion of `base:<ver>-beta` → `base:<ver>` doesn't break anything downstream.

## Test plan

- [x] Diff verified — single-line change to `publish-images.yml:144`
- [ ] After merge: re-tag v1.1.2 from local and verify `publish-images` succeeds end-to-end
- [ ] Then `post-publish-acceptance` fires (workflow_run on Publish Images success)
- [ ] Then `promote-to-stable` fires (workflow_run on acceptance success) and creates `:1.1.2` + `:latest`