### PR TITLE
refactor(ci): rename -beta tag suffix to -canary

### DIFF
--- a/.github/workflows/post-publish-acceptance.yml
+++ b/.github/workflows/post-publish-acceptance.yml
@@ -89,11 +89,11 @@ jobs:
           - lang: python
             lang_version: "3.12"
     env:
-      # Acceptance runs against -beta tags (the just-published, not-yet-validated
+      # Acceptance runs against -canary tags (the just-published, not-yet-validated
       # release). On all-green, promote-to-stable.yml retags the same digest as
       # `<ver>` + `latest`.
       IMAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
-      IMAGE_TAG_SUFFIX: -beta
+      IMAGE_TAG_SUFFIX: -canary
       LANG: ${{ matrix.lang }}
       LANG_VERSION: ${{ matrix.lang_version }}
     steps:
@@ -106,7 +106,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull published beta images
+      - name: Pull published canary images
         run: |
           set -euo pipefail
           docker pull "ghcr.io/andend-collective/runsecure/proxy:${IMAGE_VERSION}${IMAGE_TAG_SUFFIX}"

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -1,21 +1,21 @@
 # ============================================================================
-# RunSecure — Promote Beta to Stable
+# RunSecure — Promote Canary to Stable
 # ============================================================================
-# After post-publish-acceptance.yml validates a -beta release against
+# After post-publish-acceptance.yml validates a -canary release against
 # documented security claims, this workflow promotes the same image
 # digest to the stable tag.
 #
 # Promotion is server-side via `docker buildx imagetools create` —
 # no rebuild, no scan re-run. The bytes that consumers pull from
 # `:1.1.2` are byte-identical to the bytes that just passed acceptance
-# as `:1.1.2-beta`.
+# as `:1.1.2-canary`.
 #
 # Tag transitions:
-#   base:1.1.2-beta            ───retag──>  base:1.1.2
+#   base:1.1.2-canary            ───retag──>  base:1.1.2
 #   base:nightly                              base:latest
-#   <lang>:1.1.2-beta-24       ───retag──>  <lang>:1.1.2-24
+#   <lang>:1.1.2-canary-24       ───retag──>  <lang>:1.1.2-24
 #   <lang>:nightly-24                         <lang>:latest-24
-#   proxy:1.1.2-beta           ───retag──>  proxy:1.1.2
+#   proxy:1.1.2-canary           ───retag──>  proxy:1.1.2
 #   proxy:nightly                             proxy:latest
 #
 # Triggered:
@@ -35,7 +35,7 @@ on:
   workflow_dispatch:
     inputs:
       image_version:
-        description: 'Beta image version to promote (e.g. 1.1.2 — without -beta suffix)'
+        description: 'Canary image version to promote (e.g. 1.1.2 — without -canary suffix)'
         required: true
         type: string
 
@@ -71,7 +71,7 @@ jobs:
             echo "::error::could not resolve version to promote"
             exit 1
           fi
-          echo "Promoting beta-$VERSION → stable $VERSION"
+          echo "Promoting canary-$VERSION → stable $VERSION"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   promote:
@@ -84,35 +84,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # base + proxy: <ver>-beta → <ver>, nightly → latest
+          # base + proxy: <ver>-canary → <ver>, nightly → latest
           - kind: base
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary'
             stable_tag: '${{ needs.resolve-version.outputs.version }}'
             also_alias: latest
           - kind: proxy
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary'
             stable_tag: '${{ needs.resolve-version.outputs.version }}'
             also_alias: latest
-          # Language images: <ver>-beta-<langver> → <ver>-<langver>, nightly-<langver> → latest-<langver>
+          # Language images: <ver>-canary-<langver> → <ver>-<langver>, nightly-<langver> → latest-<langver>
           - kind: node
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta-24'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary-24'
             stable_tag: '${{ needs.resolve-version.outputs.version }}-24'
             also_alias: latest-24
           - kind: node
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta-22'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary-22'
             stable_tag: '${{ needs.resolve-version.outputs.version }}-22'
             also_alias: latest-22
           - kind: python
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta-3.12'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary-3.12'
             stable_tag: '${{ needs.resolve-version.outputs.version }}-3.12'
             also_alias: latest-3.12
           - kind: rust
-            beta_tag: '${{ needs.resolve-version.outputs.version }}-beta-stable'
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary-stable'
             stable_tag: '${{ needs.resolve-version.outputs.version }}-stable'
             also_alias: latest-stable
     env:
       KIND: ${{ matrix.kind }}
-      BETA: ${{ matrix.beta_tag }}
+      CANARY: ${{ matrix.canary_tag }}
       STABLE: ${{ matrix.stable_tag }}
       ALIAS: ${{ matrix.also_alias }}
       REPO: ghcr.io/andend-collective/runsecure
@@ -125,17 +125,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify beta tag exists
+      - name: Verify canary tag exists
         run: |
           set -euo pipefail
-          if ! docker buildx imagetools inspect "${REPO}/${KIND}:${BETA}" >/dev/null 2>&1; then
-            echo "::error::beta tag not found: ${REPO}/${KIND}:${BETA}"
+          if ! docker buildx imagetools inspect "${REPO}/${KIND}:${CANARY}" >/dev/null 2>&1; then
+            echo "::error::canary tag not found: ${REPO}/${KIND}:${CANARY}"
             echo "Either acceptance never ran for this version, or the publish job didn't run."
             exit 1
           fi
-          echo "Found beta: ${REPO}/${KIND}:${BETA}"
+          echo "Found canary: ${REPO}/${KIND}:${CANARY}"
 
-      - name: Promote beta digest to stable + alias (server-side retag)
+      - name: Promote canary digest to stable + alias (server-side retag)
         run: |
           set -euo pipefail
           # `imagetools create -t target source` retargets `target` at the
@@ -144,19 +144,19 @@ jobs:
           docker buildx imagetools create \
             --tag "${REPO}/${KIND}:${STABLE}" \
             --tag "${REPO}/${KIND}:${ALIAS}" \
-            "${REPO}/${KIND}:${BETA}"
-          echo "Promoted: ${REPO}/${KIND}:${BETA} → :${STABLE} + :${ALIAS}"
+            "${REPO}/${KIND}:${CANARY}"
+          echo "Promoted: ${REPO}/${KIND}:${CANARY} → :${STABLE} + :${ALIAS}"
 
-      - name: Verify both stable tags resolve to the beta digest
+      - name: Verify both stable tags resolve to the canary digest
         run: |
           set -euo pipefail
-          beta_digest=$(docker buildx imagetools inspect "${REPO}/${KIND}:${BETA}" --format '{{.Manifest.Digest}}')
+          canary_digest=$(docker buildx imagetools inspect "${REPO}/${KIND}:${CANARY}" --format '{{.Manifest.Digest}}')
           stable_digest=$(docker buildx imagetools inspect "${REPO}/${KIND}:${STABLE}" --format '{{.Manifest.Digest}}')
           alias_digest=$(docker buildx imagetools inspect "${REPO}/${KIND}:${ALIAS}" --format '{{.Manifest.Digest}}')
-          echo "beta:   $beta_digest"
+          echo "canary:   $canary_digest"
           echo "stable: $stable_digest"
           echo "alias:  $alias_digest"
-          if [ "$beta_digest" != "$stable_digest" ] || [ "$beta_digest" != "$alias_digest" ]; then
+          if [ "$canary_digest" != "$stable_digest" ] || [ "$canary_digest" != "$alias_digest" ]; then
             echo "::error::digest mismatch after retag — promotion failed"
             exit 1
           fi

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,17 +4,17 @@
 # Triggers on semver tags (v1.0.0, v1.2.3, etc.)
 # Builds multi-arch images and pushes to ghcr.io/andend-collective/runsecure/
 #
-# Image naming (beta-first publish):
-#   ghcr.io/andend-collective/runsecure/base:<version>-beta
+# Image naming (canary-first publish):
+#   ghcr.io/andend-collective/runsecure/base:<version>-canary
 #   ghcr.io/andend-collective/runsecure/base:nightly
-#   ghcr.io/andend-collective/runsecure/<lang>:<version>-beta-<lang_version>
+#   ghcr.io/andend-collective/runsecure/<lang>:<version>-canary-<lang_version>
 #   ghcr.io/andend-collective/runsecure/<lang>:nightly-<lang_version>
-#   ghcr.io/andend-collective/runsecure/proxy:<version>-beta
+#   ghcr.io/andend-collective/runsecure/proxy:<version>-canary
 #   ghcr.io/andend-collective/runsecure/proxy:nightly
 #
 # Production tags (`<version>` and `latest`) are NOT created here.
 # They are added by promote-to-stable.yml after post-publish-acceptance.yml
-# validates the beta build against documented security claims. Same
+# validates the canary build against documented security claims. Same
 # digest, server-side retag — no rebuild.
 # ============================================================================
 
@@ -85,11 +85,11 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           no-cache: ${{ github.event_name != 'push' }}
           platforms: linux/amd64,linux/arm64
-          # Beta-first publish. Acceptance suite (post-publish-acceptance.yml)
+          # Canary-first publish. Acceptance suite (post-publish-acceptance.yml)
           # validates these tags; on success, promote-to-stable.yml retags
           # the same digest as `<ver>` + `latest`.
           tags: |
-            ${{ env.IMAGE_PREFIX }}/base:${{ steps.version.outputs.version }}-beta
+            ${{ env.IMAGE_PREFIX }}/base:${{ steps.version.outputs.version }}-canary
             ${{ env.IMAGE_PREFIX }}/base:nightly
           labels: |
             org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
@@ -141,10 +141,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/base
-            BASE_TAG=${{ needs.base.outputs.version }}-beta
+            BASE_TAG=${{ needs.base.outputs.version }}-canary
             ${{ matrix.build_arg }}
           tags: |
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ needs.base.outputs.version }}-beta-${{ matrix.lang_version }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ needs.base.outputs.version }}-canary-${{ matrix.lang_version }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:nightly-${{ matrix.lang_version }}
           labels: |
             org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
@@ -176,7 +176,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.IMAGE_PREFIX }}/proxy:${{ needs.base.outputs.version }}-beta
+            ${{ env.IMAGE_PREFIX }}/proxy:${{ needs.base.outputs.version }}-canary
             ${{ env.IMAGE_PREFIX }}/proxy:nightly
           labels: |
             org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
@@ -219,7 +219,7 @@ jobs:
         # `${{ env.IMAGE_PREFIX }}` resolves empty there. Step-level env is
         # evaluated when the step runs and resolves correctly.
         env:
-          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/base:${{ needs.base.outputs.version }}-beta"
+          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/base:${{ needs.base.outputs.version }}-canary"
         run: |
           set -euo pipefail
           grype "$IMAGE_REF" --output table --fail-on high --only-fixed \
@@ -262,7 +262,7 @@ jobs:
 
       - name: Grype scan (proxy image) — fail on HIGH/CRITICAL with fix
         env:
-          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/proxy:${{ needs.base.outputs.version }}-beta"
+          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/proxy:${{ needs.base.outputs.version }}-canary"
         run: |
           set -euo pipefail
           grype "$IMAGE_REF" --output table --fail-on high --only-fixed \

--- a/README.md
+++ b/README.md
@@ -104,17 +104,17 @@ apt install docker.io gh
 
 ## Quick Start
 
-> **Heads-up on versioning.** Releases follow a beta-first promotion
+> **Heads-up on versioning.** Releases follow a canary-first promotion
 > pipeline:
 >
 > | Tag | Meaning | When to use |
 > |---|---|---|
 > | `1.2.3` (or `latest`) | Promoted to stable after acceptance suite passed against the same digest | **Production** — every consumer should pin one of these |
-> | `1.2.3-beta` (or `nightly`) | Built and Grype-scanned, but acceptance results not yet validated | Bleeding-edge testing only — the digest may regress on a documented security claim |
+> | `1.2.3-canary` (or `nightly`) | Built and Grype-scanned, but acceptance results not yet validated | Bleeding-edge testing only — the digest may regress on a documented security claim |
 >
-> The `:1.2.3-beta` digest is byte-identical to `:1.2.3` after promotion
+> The `:1.2.3-canary` digest is byte-identical to `:1.2.3` after promotion
 > — same artifact, just a server-side retag. If acceptance fails, the
-> beta tag stays and no stable tag is created.
+> canary tag stays and no stable tag is created.
 
 ### Clone-and-run (recommended)
 
@@ -326,7 +326,7 @@ the actual GHCR images against documented security claims. The workflow
 
 Each check is tagged with a claim ID (`H01`, `R02`, `N03`, …) that maps
 to a numbered claim in [SECURITY.md](./SECURITY.md). A failure GATES THE
-PROMOTION: the `-beta` tag exists and consumers can opt into it, but
+PROMOTION: the `-canary` tag exists and consumers can opt into it, but
 the stable `<version>` and `latest` tags are not created until the
 acceptance suite is fully green. The promotion (`promote-to-stable.yml`)
 runs server-side via `docker buildx imagetools create` — no rebuild,
@@ -367,10 +367,10 @@ What you see in the Security tab when a claim fails:
 |---|---|
 | **Rule** | `H03` — *"Package manager removed (apt/dpkg/aptitude)"* |
 | **Severity** | error |
-| **Description** | "Acceptance claim H03 FAILED for ghcr.io/.../node:1.2.3-beta-24: package manager 'apt' still present at /usr/bin/apt" |
+| **Description** | "Acceptance claim H03 FAILED for ghcr.io/.../node:1.2.3-canary-24: package manager 'apt' still present at /usr/bin/apt" |
 | **Location** | `SECURITY.md` line 1 (anchor: layer-1-image-hardening-build-time) |
 | **Help** | Markdown explaining the claim + link to the SECURITY.md section |
-| **Fingerprint** | `claim/v1=H03 image-ref/v1=ghcr.io/.../node:1.2.3-beta-24` (deduplicates across runs) |
+| **Fingerprint** | `claim/v1=H03 image-ref/v1=ghcr.io/.../node:1.2.3-canary-24` (deduplicates across runs) |
 
 The `partialFingerprints` mean the same finding on the same image-ref
 shows as one persistent issue across re-runs (not a new finding each

--- a/tests/acceptance/sarif-emitter.py
+++ b/tests/acceptance/sarif-emitter.py
@@ -11,7 +11,7 @@ GitHub Code Scanning surfaces in the Security tab.
 Usage:
     python3 sarif-emitter.py \\
         --claims tests/acceptance/claims.yml \\
-        --image-ref ghcr.io/andend-collective/runsecure/node:1.2.3-beta-24 \\
+        --image-ref ghcr.io/andend-collective/runsecure/node:1.2.3-canary-24 \\
         --commit-sha abc123 \\
         < acceptance-output.txt > acceptance.sarif
 
@@ -196,7 +196,7 @@ def main():
     p.add_argument("--claims", required=True, type=Path,
                    help="Path to claims.yml (catalog of every acceptance claim ID)")
     p.add_argument("--image-ref", default="(unspecified)",
-                   help="The published image being tested (e.g. ghcr.io/.../node:1.2.3-beta-24)")
+                   help="The published image being tested (e.g. ghcr.io/.../node:1.2.3-canary-24)")
     p.add_argument("--commit-sha", default="(unspecified)",
                    help="Git commit SHA the acceptance run was for")
     p.add_argument("--output", "-o", type=Path, default=None,


### PR DESCRIPTION
## Summary

The pre-acceptance tag is more accurately a **canary** than a **beta** — it's an early sample published deliberately so the acceptance suite can shoot it down before users see it. \"Beta\" implies feature-complete-pending-polish, which isn't what's happening here.

After this rename:
- pre-acceptance: \`<ver>-canary\` (was \`<ver>-beta\`)
- post-promotion: \`<ver>\` + \`latest\` — unchanged (bare semver stays)

## ⚠️ Hold the merge

The in-flight v1.1.2 release ([run 25268826568](https://github.com/AndEnd-Collective/RunSecure/actions/runs/25268826568)) is using \`-beta\` tags. Merging this PR would make post-publish-acceptance fail to find the just-published images. Wait until v1.1.2 has fully completed (publish → acceptance → promote) before merging this. Then the next release (v1.1.3+) will use the new \`-canary\` scheme.

## Why bare \`<ver>\` stays for promoted (not \`-stable\`)

- Consumers pin \`version: 1.1.2\` in their \`runner.yml\` — clean semver tag is universal convention (Docker Hub, npm, PyPI, GHCR all do this).
- A \`-stable\` suffix would force consumers to write \`1.1.2-stable\` (ugly) or maintain both \`1.1.2\` and \`1.1.2-stable\` aliases (twice the surface area).
- Pre-release qualifiers carry suffixes; the production release is bare.

## Files

- \`publish-images.yml\` — 5 tag refs + comments
- \`post-publish-acceptance.yml\` — 3 refs + \`IMAGE_TAG_SUFFIX\`
- \`promote-to-stable.yml\` — matrix entries, verify step, var name (\`beta_digest\` → \`canary_digest\`)
- \`README.md\` — consumer-facing tag table
- \`tests/acceptance/sarif-emitter.py\` — docstring example

README line 183 keeps lowercase \"beta\" — that's Rust upstream's \`beta\` toolchain channel, not our tag.

## Test plan

- [x] grep for any remaining \`beta\`/\`Beta\`/\`BETA\` in scope — only Rust channel ref remains
- [x] grep for \`beta_\` shell vars — all renamed to \`canary_\`
- [ ] Wait for in-flight v1.1.2 to complete on \`-beta\` scheme
- [ ] Merge
- [ ] Trigger next release (v1.1.3) and verify it produces \`-canary\` tags