### PR TITLE
fix(ci): bump workflow uses RELEASE_TOKEN so tag push fires cascade

### DIFF
--- a/.github/workflows/weekly-version-bump.yml
+++ b/.github/workflows/weekly-version-bump.yml
@@ -65,6 +65,15 @@ jobs:
           # Need full history + tags to find the latest semver tag.
           fetch-depth: 0
           fetch-tags: true
+          # Use a PAT (or GitHub App token) so the resulting tag-push
+          # fires downstream workflows (publish-images.yml). Tags pushed
+          # via the default GITHUB_TOKEN are deliberately suppressed by
+          # GitHub to prevent recursion — which silently breaks our
+          # bump → publish → acceptance → promote cascade.
+          # Falls back to GITHUB_TOKEN if RELEASE_TOKEN isn't configured;
+          # in that case the cascade must be kicked off manually by
+          # re-pushing the tag from a local terminal.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Compute next version
         id: next_version


### PR DESCRIPTION
## Summary

Closes #29.

The weekly bump workflow pushes a new semver tag using the default `GITHUB_TOKEN`. GitHub deliberately suppresses workflow events caused by `GITHUB_TOKEN` actions (to prevent recursion) — which silently breaks the bump → publish → acceptance → promote cascade. Tags appear on origin but `publish-images.yml` never fires.

This PR makes `actions/checkout` read from a `RELEASE_TOKEN` repository secret if present, falling back to `GITHUB_TOKEN` (which preserves current behavior — manual local re-push remains the workaround).

## Provisioning required

One-time, by a repo admin:
1. Create a fine-grained PAT scoped to this repo with: `contents: write`
2. Save as repository secret `RELEASE_TOKEN`
3. Rotate per your usual cadence

A GitHub App token (via `tibdex/github-app-token` or similar) is more maintainable long-term but PAT is acceptable here.

## Test plan

- [x] Diff is one block in `weekly-version-bump.yml` — adds `token:` to the existing checkout step
- [x] Falls back to `GITHUB_TOKEN` if secret unset (current behavior preserved)
- [ ] After RELEASE_TOKEN provisioned: dispatch `weekly-version-bump.yml` manually, confirm `publish-images.yml` auto-fires on the resulting tag push
- [ ] Next Monday's cron fires the full chain end-to-end with no human re-push needed