### PR TITLE
fix(orchestrator): per-repo lockfile prevents concurrent collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,27 @@ entrypoint reads it from a tmpfs file and removes the file after
 reading. The orchestrator-side switch to file-mode is tracked as a
 follow-up; see [SECURITY.md §14](./SECURITY.md#known-limitations).
 
+### Concurrency: one orchestrator per repo
+
+The orchestrator acquires a per-repo lockfile at `${TMPDIR:-/tmp}/runsecure-<repo-slug>.lock`
+on startup. A second invocation against the same repo fails fast with a
+clear error rather than silently colliding on container names.
+
+Two orchestrators against **different repos** can run concurrently — the
+lock is per-repo, and per-job container names (`rs-<repo>-jobN`) don't
+overlap.
+
+Why the lock matters: without it, a second `docker compose up` against
+the same repo would treat the existing container as a "recreate" target,
+killing the first orchestrator's in-flight container. That orphans the
+GitHub-side runner registration (`busy + offline`) until the JIT token
+expires (~1 hour), during which the assigned job sits `in_progress` and
+blocks PR check rollup. Fail-fast on the host avoids the entire class.
+
+If the lock looks stale (orchestrator was killed without cleanup), the
+next invocation detects the dead PID, logs `Stale lock from PID N — taking
+over`, and proceeds. Manual cleanup: `rm -rf /tmp/runsecure-*.lock`.
+
 ### Updating
 
 Releases follow weekly cadence. Every Monday at 02:30 UTC, the

--- a/infra/scripts/run.sh
+++ b/infra/scripts/run.sh
@@ -96,6 +96,30 @@ RUNSECURE_VERSION=$(yq '.version // "local"' "$RUNNER_YML")
 REPO_SHORT=$(echo "$REPO" | sed 's|.*/||; s/[^a-zA-Z0-9_-]/-/g' | tr '[:upper:]' '[:lower:]')
 CONTAINER_PREFIX="rs-${REPO_SHORT}"
 
+# --- Reject concurrent orchestrators against the same repo ------------------
+# Two orchestrators against the same repo would collide on the per-job
+# RUNNER_NAME (rs-<repo>-job1, ...). Compose treats the second `up` as a
+# recreate of the existing container, killing the first orchestrator's
+# in-flight container — which orphans the GitHub-side runner registration
+# (busy + offline) until the JIT token expires (~1h). Fail fast instead.
+#
+# Lock is per-repo (not global): two orchestrators against DIFFERENT repos
+# can run concurrently — their container names don't collide.
+LOCKDIR="${TMPDIR:-/tmp}/runsecure-${REPO_SHORT}.lock"
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    if [[ -f "$LOCKDIR/pid" ]] && kill -0 "$(cat "$LOCKDIR/pid")" 2>/dev/null; then
+        echo "[RunSecure] ERROR: another orchestrator is already running for $REPO" >&2
+        echo "[RunSecure] PID: $(cat "$LOCKDIR/pid"), lock: $LOCKDIR" >&2
+        echo "[RunSecure] Stop it first (or kill the PID) before launching a new one." >&2
+        exit 1
+    fi
+    # Stale lock — old process is gone. Take over.
+    echo "[RunSecure] Stale lock from PID $(cat "$LOCKDIR/pid" 2>/dev/null) — taking over" >&2
+    rm -rf "$LOCKDIR"
+    mkdir "$LOCKDIR"
+fi
+echo "$$" > "$LOCKDIR/pid"
+
 # --- Build/cache the project image ------------------------------------------
 echo "=== RunSecure Orchestrator ==="
 echo "Project: $PROJECT_DIR"
@@ -206,6 +230,12 @@ cleanup() {
         $DC -f "${RUNSECURE_ROOT}/infra/docker-compose.yml" -f "$_cleanup_compose" down --remove-orphans 2>/dev/null || true
     else
         $DC -f "${RUNSECURE_ROOT}/infra/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+    fi
+    # Release the per-repo lock. Only delete if WE own it (matching PID),
+    # so a "stale lock takeover" by another orchestrator doesn't get its
+    # own lock deleted by our cleanup.
+    if [[ -d "${LOCKDIR:-}" ]] && [[ "$(cat "$LOCKDIR/pid" 2>/dev/null)" == "$$" ]]; then
+        rm -rf "$LOCKDIR"
     fi
 }
 trap cleanup EXIT

--- a/infra/scripts/run.sh
+++ b/infra/scripts/run.sh
@@ -120,6 +120,19 @@ if ! mkdir "$LOCKDIR" 2>/dev/null; then
 fi
 echo "$$" > "$LOCKDIR/pid"
 
+# Install the lock-release trap RIGHT NOW, before anything else can fail.
+# The full cleanup (defined further down) extends this to also tear down
+# compose; until then, this minimal trap guarantees the lock is released
+# even if we exit early (no Docker, no gh auth, validation error, etc.).
+# Only delete the lock if WE own it (PID match) — protects against stale-
+# takeover races.
+_release_lock() {
+    if [[ -d "${LOCKDIR:-}" ]] && [[ "$(cat "$LOCKDIR/pid" 2>/dev/null)" == "$$" ]]; then
+        rm -rf "$LOCKDIR"
+    fi
+}
+trap _release_lock EXIT
+
 # --- Build/cache the project image ------------------------------------------
 echo "=== RunSecure Orchestrator ==="
 echo "Project: $PROJECT_DIR"
@@ -231,13 +244,12 @@ cleanup() {
     else
         $DC -f "${RUNSECURE_ROOT}/infra/docker-compose.yml" down --remove-orphans 2>/dev/null || true
     fi
-    # Release the per-repo lock. Only delete if WE own it (matching PID),
-    # so a "stale lock takeover" by another orchestrator doesn't get its
-    # own lock deleted by our cleanup.
-    if [[ -d "${LOCKDIR:-}" ]] && [[ "$(cat "$LOCKDIR/pid" 2>/dev/null)" == "$$" ]]; then
-        rm -rf "$LOCKDIR"
-    fi
+    # Reuse the same lock-release helper installed earlier — keeps the
+    # PID-ownership check in one place.
+    _release_lock
 }
+# Extend the early lock-only trap to also tear down compose. The lock-release
+# is still PID-owned-only via _release_lock, so this is safe.
 trap cleanup EXIT
 
 for i in $(seq 1 "$MAX_JOBS"); do

--- a/tests/unit/test-orchestrator-lock.sh
+++ b/tests/unit/test-orchestrator-lock.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# ============================================================================
+# RunSecure Unit Test — Per-repo orchestrator lock
+# ============================================================================
+# Verifies that two concurrent invocations of run.sh against the same repo
+# fail fast on the second one (per-repo lockfile rejects the collision),
+# and that a stale lock from a dead PID is taken over cleanly.
+#
+# Runs entirely on the host without launching containers — relies on run.sh
+# erroring out at later stages (no Docker available in CI, or auth missing)
+# AFTER the lock is acquired/checked.
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNSECURE_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_SCRIPT="${RUNSECURE_ROOT}/infra/scripts/run.sh"
+
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+WORKDIR=$(mktemp -d)
+PROJECT_DIR="${WORKDIR}/project"
+mkdir -p "$PROJECT_DIR/.github"
+cat > "$PROJECT_DIR/.github/runner.yml" <<'YAML'
+runtime: node:24
+tools: []
+http_egress: []
+YAML
+
+# Use a unique repo name per test run so we don't trip over lingering locks
+# from other dev work.
+REPO="testowner/lock-test-$$-$(date +%s)"
+REPO_SLUG=$(echo "$REPO" | sed 's|.*/||; s/[^a-zA-Z0-9_-]/-/g' | tr '[:upper:]' '[:lower:]')
+LOCK_PATH="${TMPDIR:-/tmp}/runsecure-${REPO_SLUG}.lock"
+
+cleanup_locks() {
+    rm -rf "$LOCK_PATH"
+    rm -rf "$WORKDIR"
+}
+trap cleanup_locks EXIT
+
+echo -e "\n${BOLD}=== Orchestrator Lock Tests ===${NC}\n"
+
+# ----------------------------------------------------------------------------
+# Test 1: Lock is created when run.sh starts
+# ----------------------------------------------------------------------------
+echo -e "${BOLD}--- 1. lock acquired on startup ---${NC}"
+
+# Run with no auth so it errors out after the lock check. We verify by
+# checking that the lock dir was created, then verifying it gets cleaned
+# up on EXIT.
+"$RUN_SCRIPT" --project "$PROJECT_DIR" --repo "$REPO" --max-jobs 1 >/dev/null 2>&1 || true
+
+# After the script exits cleanly, the lock should be gone (cleanup trap).
+if [[ ! -d "$LOCK_PATH" ]]; then
+    pass "Lock cleaned up after run.sh exits"
+else
+    fail "Lock at $LOCK_PATH not cleaned up"
+    rm -rf "$LOCK_PATH"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 2: Second invocation rejected when first PID is alive
+# ----------------------------------------------------------------------------
+echo -e "\n${BOLD}--- 2. concurrent invocation rejected ---${NC}"
+
+# Simulate a live first orchestrator by manually creating the lock with our
+# own PID (we know we're alive — kill -0 $$ succeeds).
+mkdir "$LOCK_PATH"
+echo "$$" > "$LOCK_PATH/pid"
+
+OUTPUT=$("$RUN_SCRIPT" --project "$PROJECT_DIR" --repo "$REPO" --max-jobs 1 2>&1 || true)
+if echo "$OUTPUT" | grep -q "another orchestrator is already running"; then
+    pass "Rejects concurrent invocation against same repo"
+else
+    fail "Did not reject concurrent invocation; output: $OUTPUT"
+fi
+
+# Lock should still be intact (not deleted by the rejected invocation).
+if [[ -d "$LOCK_PATH" ]] && [[ "$(cat "$LOCK_PATH/pid")" == "$$" ]]; then
+    pass "Original lock untouched by rejected invocation"
+else
+    fail "Original lock was modified by the rejected invocation"
+fi
+
+rm -rf "$LOCK_PATH"
+
+# ----------------------------------------------------------------------------
+# Test 3: Stale lock (dead PID) is taken over
+# ----------------------------------------------------------------------------
+echo -e "\n${BOLD}--- 3. stale lock from dead PID is taken over ---${NC}"
+
+# Use a PID that's vanishingly unlikely to be alive: 99999999 is well past
+# the typical pid_max (4M on Linux, 99999 on macOS).
+mkdir "$LOCK_PATH"
+echo "99999999" > "$LOCK_PATH/pid"
+
+OUTPUT=$("$RUN_SCRIPT" --project "$PROJECT_DIR" --repo "$REPO" --max-jobs 1 2>&1 || true)
+if echo "$OUTPUT" | grep -q "Stale lock from PID 99999999 — taking over"; then
+    pass "Detects and takes over stale lock"
+else
+    fail "Did not take over stale lock; output: $OUTPUT"
+fi
+
+# After the second invocation exits, lock should be cleaned up.
+if [[ ! -d "$LOCK_PATH" ]]; then
+    pass "Lock cleaned up after stale-lock takeover run"
+else
+    fail "Lock not cleaned up after stale-lock takeover"
+    rm -rf "$LOCK_PATH"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 4: Different repos can run concurrently (lock is per-repo)
+# ----------------------------------------------------------------------------
+echo -e "\n${BOLD}--- 4. different repos do not collide ---${NC}"
+
+OTHER_REPO="testowner/different-repo-$$-$(date +%s)"
+OTHER_REPO_SLUG=$(echo "$OTHER_REPO" | sed 's|.*/||; s/[^a-zA-Z0-9_-]/-/g' | tr '[:upper:]' '[:lower:]')
+OTHER_LOCK="${TMPDIR:-/tmp}/runsecure-${OTHER_REPO_SLUG}.lock"
+
+# Hold a live lock for the FIRST repo
+mkdir "$LOCK_PATH"
+echo "$$" > "$LOCK_PATH/pid"
+
+# Try the SECOND repo — should NOT be rejected by the first repo's lock
+OUTPUT=$("$RUN_SCRIPT" --project "$PROJECT_DIR" --repo "$OTHER_REPO" --max-jobs 1 2>&1 || true)
+if echo "$OUTPUT" | grep -q "another orchestrator is already running"; then
+    fail "Rejected a different-repo invocation (lock scope is too broad)"
+else
+    pass "Different-repo invocation NOT rejected by first repo's lock"
+fi
+
+# Cleanup the second repo's lock if it leaked
+rm -rf "$OTHER_LOCK"
+rm -rf "$LOCK_PATH"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo -e "${BOLD}=== Summary ===${NC}"
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes the "orchestrator orphans GitHub jobs on SIGTERM" issue raised in feedback from the VLAD project — but with a different fix than they proposed (their fix doesn't apply to our JIT architecture).

## The bug

Two `run.sh` invocations against the same repo collide on the per-job container name (`rs-<repo>-job1`). Compose treats the second `up` as a recreate of the existing container, killing the first orchestrator's in-flight container. That orphans the GitHub-side runner registration (`busy + offline`) until the JIT token expires (~1h), during which the assigned job stays `in_progress` and blocks PR check rollup.

## The fix

Per-repo lockfile at `${TMPDIR:-/tmp}/runsecure-<slug>.lock`:
- Acquired before any compose operation
- Second invocation against the **same repo** → fail fast with clear error
- Different repos → still concurrent (lock is per-repo)
- Stale lock from dead PID → automatic takeover with log
- Released on EXIT only if we own it (PID match — protects against takeover races)

## Why not the proposed fix

The feedback proposed trapping SIGTERM and calling `docker exec runner ./config.sh remove --token "${RUNNER_TOKEN}"`. That doesn't work for us:

1. **We use JIT, not persistent registration**: `run.sh:217` calls `generate-jitconfig`. JIT runners have no persistent token; `config.sh remove --token X` would error out
2. **`trap cleanup EXIT` already exists** at `run.sh:211` — EXIT fires on SIGTERM/SIGINT/normal exit
3. The **real root cause** is the host-side container-name collision, not in-container deregistration

The lockfile fixes the actual class of failures.

## Tests

`tests/unit/test-orchestrator-lock.sh` — 6 assertions, all pass:
- Lock created on startup → cleaned up after exit
- Concurrent same-repo invocation rejected with clear message
- Original lock untouched by the rejected invocation (no collateral damage)
- Stale lock (dead PID) detected and taken over
- Different repos do NOT collide

`tests/unit/test-run-args.sh` — 19 assertions, still pass.

## Test plan

- [x] New unit test passes (6/6)
- [x] Existing run-args test still passes (19/19)
- [ ] Manual: in two terminals, `./infra/scripts/run.sh --project . --repo AndEnd-Collective/RunSecure` — second one should refuse immediately
- [ ] Manual: `kill -9` an active orchestrator, then re-run — should log "Stale lock... taking over"

## Files

- `infra/scripts/run.sh` — lock acquire/release + cleanup integration (30 lines)
- `README.md` — new "Concurrency: one orchestrator per repo" section under Operational notes
- `tests/unit/test-orchestrator-lock.sh` — new test file (160 lines)