### PR TITLE
test(acceptance): cover all 4 language images

### DIFF
--- a/.github/workflows/post-publish-acceptance.yml
+++ b/.github/workflows/post-publish-acceptance.yml
@@ -84,10 +84,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Every language image that promote-to-stable.yml retags MUST be
+          # acceptance-tested here. If you add a new lang/version to the
+          # publish matrix, add it here too — otherwise a regression would
+          # ship to `:latest` without any check rejecting it.
           - lang: node
             lang_version: "24"
+          - lang: node
+            lang_version: "22"
           - lang: python
             lang_version: "3.12"
+          - lang: rust
+            lang_version: "stable"
     env:
       # Acceptance runs against -canary tags (the just-published, not-yet-validated
       # release). On all-green, promote-to-stable.yml retags the same digest as


### PR DESCRIPTION
## Summary

Coverage gap discovered while validating v1.1.4 release: `promote-to-stable.yml` retags six images (`base`, `proxy`, `node:24`, `node:22`, `python:3.12`, `rust:stable`) but `post-publish-acceptance.yml` only validated two (`node:24`, `python:3.12`). Result: `node:22` and `rust:stable` shipped to `:latest-22` / `:latest-stable` each release without any check rejecting a regression.

This PR expands the acceptance matrix to cover all four language images.

## What this catches that wasn't caught before

- A Rust toolchain installer that drops a setuid binary in `/usr/local/bin` (H05) — only manifests in the rust image
- An `apt` package added to `images/node.Dockerfile` but not purged (H03) — would only manifest in node images
- Cap-drop or seccomp differences introduced by a per-language base-layer modification (R01-R04)
- Anything else that's hardening-correct on `node:24` but regressed on `node:22` or `rust:stable`

## Skip behavior

Acceptance checks already handle "interpreter not available" gracefully — `r01-cap-drop.sh` falls back if `python3` isn't in the rust image. Skips are reported in the SARIF as `note` severity, not failure. So Rust running with fewer tools available is fine — the H* hardening claims (which don't need an interpreter) still all run.

## Cost

- **Wall clock**: ~5 min (4 legs in parallel; same as 2 because there's no serial dep)
- **Compute**: ~2x (4 jobs vs 2)
- Trivial

## Invariant codified

The matrix gets a new comment:

> Every language image that `promote-to-stable.yml` retags MUST be acceptance-tested here. If you add a new lang/version to the publish matrix, add it here too — otherwise a regression would ship to `:latest` without any check rejecting it.

## Test plan

- [x] YAML still valid
- [ ] After merge: trigger v1.1.5 → confirm acceptance shows 4 jobs (node:24, node:22, python:3.12, rust:stable) all run
- [ ] Confirm rust acceptance shows skips for python-dependent checks but no failures