### PR TITLE
feat(ci): auto-create GitHub Release after successful promote

### DIFF
--- a/.github/workflows/post-publish-acceptance.yml
+++ b/.github/workflows/post-publish-acceptance.yml
@@ -84,10 +84,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Every language image that promote-to-stable.yml retags MUST be
+          # acceptance-tested here. If you add a new lang/version to the
+          # publish matrix, add it here too — otherwise a regression would
+          # ship to `:latest` without any check rejecting it.
           - lang: node
             lang_version: "24"
+          - lang: node
+            lang_version: "22"
           - lang: python
             lang_version: "3.12"
+          - lang: rust
+            lang_version: "stable"
     env:
       # Acceptance runs against -canary tags (the just-published, not-yet-validated
       # release). On all-green, promote-to-stable.yml retags the same digest as

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -40,7 +40,9 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # contents:write needed by the `release` job to create a GitHub Release
+  # after successful promotion. Other jobs only need read.
+  contents: write
   packages: write
 
 jobs:
@@ -161,3 +163,49 @@ jobs:
             exit 1
           fi
           echo "Digests match — promotion verified atomic."
+
+  # --- Create GitHub Release for the promoted version ------------------------
+  # Fires only after the entire promote matrix succeeds. The Release reflects
+  # what's actually pullable as stable from GHCR (canary that passed
+  # acceptance and was retagged), not just what got tagged in git. Notes are
+  # auto-generated from PRs/commits since the previous tag.
+  release:
+    needs: [resolve-version, promote]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.resolve-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Skip if Release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists — skipping creation"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release with auto-generated notes
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # --generate-notes: GitHub auto-builds notes from merged PRs and
+          # commits between the previous tag and this one. No external action
+          # needed; gh CLI is preinstalled on ubuntu-latest.
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --notes-start-tag "$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -A1 "^v${VERSION}$" | tail -1)"
+          echo "Created Release: v${VERSION}"


### PR DESCRIPTION
## Summary

The Releases tab on github.com was stale: only v1.0.1 → v1.1.0 (April 6) ever appeared as Releases. After v1.1.0, the bump → publish → acceptance → promote pipeline created git tags + GHCR images but never GitHub Releases. Consumers following the Releases tab as a changelog saw the project as dormant for ~4 weeks.

This PR adds a `release` job to `promote-to-stable.yml` that fires after the promote matrix succeeds, creating a GitHub Release with auto-generated notes (from merged PRs + commits since the previous tag).

## Why after promote, not after publish or after bump

- After bump: a Release would exist for a version that hasn't been built yet — misleading
- After publish: a Release would exist for a canary that hasn't passed acceptance — could ship a known-broken release
- **After promote**: the Release reflects exactly what's pullable as stable (the digest that passed acceptance and was retagged to `:latest`)

## Idempotency

`gh release view "v$VERSION"` is checked first; if a Release already exists (e.g. backfilled by hand), the create step is skipped rather than failing.

## Backfill

The 4 missing Releases (v1.1.1, v1.1.2, v1.1.3, v1.1.4) were backfilled manually before this PR. Releases tab now shows v1.1.4 as Latest. Going forward, every promotion auto-publishes the Release.

## Test plan

- [x] YAML validates
- [x] Backfill complete — Releases tab shows v1.1.0 → v1.1.4
- [ ] After merge: trigger v1.1.5 → confirm `release` job runs and creates the Release with auto-generated notes
- [ ] If the next bump's run is replayed (workflow_dispatch a second time), confirm the idempotency check skips re-creation