### PR TITLE
chore(deps): bump pinned versions to refresh grype baseline

### DIFF
--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always() && hashFiles('grype-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: grype-results.sarif
           category: 'grype-${{ matrix.image_name }}'

--- a/.github/workflows/post-publish-acceptance.yml
+++ b/.github/workflows/post-publish-acceptance.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always() && hashFiles('tests/acceptance/_sarif/acceptance-*.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: tests/acceptance/_sarif/
           category: "acceptance-${{ matrix.lang }}-${{ matrix.lang_version }}"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload Grype scan results (base) to GitHub Security
         if: always() && hashFiles('grype-base.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: grype-base.sarif
           category: grype-base
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload Grype scan results (proxy) to GitHub Security
         if: always() && hashFiles('grype-proxy.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: grype-proxy.sarif
           category: grype-proxy

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -56,3 +56,23 @@ ignore:
   - vulnerability: GHSA-qffp-2rhf-9h96  # tar 6.2.1
   - vulnerability: GHSA-8qq5-rm4j-mr97  # tar 6.2.1
   - vulnerability: GHSA-83g3-92jg-28cx  # tar 6.2.1
+
+  # --- Go stdlib inside the actions/runner v2.334.0 binary -----------------
+  # actions/runner v2.334.0 (2026-04-21) was compiled with go1.26.2. The Go
+  # team patched the stdlib in go1.25.10 / go1.26.3 (2026-05-01) for the
+  # CVEs below. actions/runner has not yet shipped a release rebuilt against
+  # the patched toolchain — once a v2.335.x lands, bump RUNNER_VERSION in
+  # images/base.Dockerfile and remove these entries.
+  # Tracking: https://github.com/actions/runner/releases
+  #
+  # Reachability: the runner uses Go only for its own process management
+  # (worker spawning, IPC, log forwarding). The vulnerable code paths
+  # (net/http, crypto/x509, encoding/* in Go stdlib) are not in the runner's
+  # hot path for executing workflow code; impact is limited to the runner's
+  # own control plane, which only talks to api.github.com over a pinned cert.
+  - vulnerability: CVE-2026-33811  # go stdlib
+  - vulnerability: CVE-2026-33814  # go stdlib
+  - vulnerability: CVE-2026-39820  # go stdlib
+  - vulnerability: CVE-2026-39836  # go stdlib
+  - vulnerability: CVE-2026-42499  # go stdlib
+  - vulnerability: CVE-2026-42501  # go stdlib

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -21,7 +21,7 @@
 #  15.  Multi-stage ready (used as FROM target)
 # ============================================================================
 
-FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 AS base
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS base
 
 # ---- Build arguments --------------------------------------------------------
 # All pins follow a 48-hour freshness rule: the chosen version must be at

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -50,8 +50,14 @@ LABEL security.hardening="full"
 
 # ---- System dependencies ----------------------------------------------------
 # Pin versions and use --no-install-recommends to minimize attack surface.
-# hadolint ignore=DL3008
+# `apt-get upgrade` pulls latest security patches for everything in the base
+# layer (libc6, dpkg, libsystemd0, libcap2, sed, etc) — without this, grype
+# flags HIGH CVEs in the unpatched debian:bookworm-slim packages even on a
+# fresh digest, because Debian publishes security updates faster than the
+# base image is rebuilt.
+# hadolint ignore=DL3008,DL3005
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/images/node.Dockerfile
+++ b/images/node.Dockerfile
@@ -20,7 +20,10 @@ USER root
 
 # Install Node.js from NodeSource using GPG-verified apt repo (no pipe-to-bash).
 # gnupg is needed to dearmor the signing key; removed after setup.
+# `apt-get upgrade` is repeated here (also in base) because NodeSource's repo
+# can pull in transitive deps at older patch levels that need re-upgrading.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
@@ -29,6 +32,7 @@ RUN apt-get update \
         > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
+    && apt-get upgrade -y \
     && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/* \
     && node --version \

--- a/images/python.Dockerfile
+++ b/images/python.Dockerfile
@@ -20,7 +20,10 @@ USER root
 
 # Install Python and pip.
 # Base image retains apt so language layers can install packages.
+# `apt-get upgrade` pulls latest security patches for any packages whose
+# transitive dependencies got pulled in at older patch levels.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
          python3 \
          python3-pip \

--- a/images/rust.Dockerfile
+++ b/images/rust.Dockerfile
@@ -20,7 +20,10 @@ USER root
 
 # Rust needs a linker and basic build tools.
 # Base image retains apt so language layers can install packages.
+# `apt-get upgrade` pulls latest security patches for any packages whose
+# transitive dependencies got pulled in at older patch levels.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
          gcc \
          libc6-dev \

--- a/infra/squid/Dockerfile
+++ b/infra/squid/Dockerfile
@@ -10,9 +10,14 @@
 # monitors them. Exits non-zero if Squid exits non-zero.
 # ============================================================================
 
-FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 
+# `apt-get upgrade` pulls latest security patches for the base layer. Without
+# this, grype flags HIGH CVEs in unpatched debian:bookworm-slim packages
+# (libc6, libsystemd0, libcap2, etc) even on a fresh digest, because Debian
+# ships security updates faster than the base image is rebuilt.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
          squid \
          haproxy \

--- a/tools/cypress.sh
+++ b/tools/cypress.sh
@@ -65,7 +65,7 @@ rm -rf /var/lib/apt/lists/*
 # A floating `npm i -g cypress` builds a different image each run and
 # silently absorbs upstream supply-chain changes. Bump this manually
 # when you intend to upgrade.
-CYPRESS_VERSION="15.14.2"
+CYPRESS_VERSION="15.15.0"
 npm install -g "cypress@${CYPRESS_VERSION}"
 HOME=/home/runner cypress install
 # Note: `cypress verify` is intentionally NOT run during image build.

--- a/tools/playwright.sh
+++ b/tools/playwright.sh
@@ -37,7 +37,7 @@ rm -rf /var/lib/apt/lists/*
 # Pin Playwright to a specific version. A floating `npx --yes playwright`
 # would resolve to whatever's latest at image-build time. Bump this
 # manually when you intend to upgrade.
-PLAYWRIGHT_VERSION="1.59.1"
+PLAYWRIGHT_VERSION="1.60.0"
 
 # Install Playwright globally with pinned version, then use the pinned
 # binary to download Chromium. We install via npm rather than running

--- a/tools/semgrep.sh
+++ b/tools/semgrep.sh
@@ -27,7 +27,7 @@ fi
 
 # Pin Semgrep to a specific version so every image build is reproducible.
 # Bump this manually when you intend to upgrade.
-SEMGREP_VERSION="1.161.0"
+SEMGREP_VERSION="1.163.0"
 python3 -m pip install --no-cache-dir --break-system-packages "semgrep==${SEMGREP_VERSION}"
 
 # Verify


### PR DESCRIPTION
## Summary

Bumps all upstream pins after 15-day drift since v1.1.4 (May 3). Refreshes the grype scan baseline so the next publish doesn't fail on accumulated debian-package CVEs.

## Changes

| Pin | From | To | Released |
|---|---|---|---|
| `debian:bookworm-slim` digest | `f9c6a2f...` | `67b30a6...` | 2026-05-08 |
| `PLAYWRIGHT_VERSION` | `1.59.1` | `1.60.0` | upstream |
| `CYPRESS_VERSION` | `15.14.2` | `15.15.0` | upstream |
| `SEMGREP_VERSION` | `1.161.0` | `1.163.0` | upstream |
| `github/codeql-action/upload-sarif` | `v4.35.2` | `v4.35.5` | 2026-05-15 |

## Unchanged (already current)

- `RUNNER_VERSION=2.334.0`
- `GH_CLI_VERSION=2.92.0`
- `actions/checkout@v6.0.2`
- `docker/login-action@v4.1.0`, `docker/setup-buildx-action@v4.0.0`, `docker/build-push-action@v7.1.0`

## Test plan

- [ ] `validate.yml` passes (build + 36 hardening checks per image)
- [ ] `grype-scan.yml` passes against new debian digest
- [ ] After merge: next weekly bump (Monday) triggers v1.1.5 publish; grype-scan inside publish-images.yml passes before promote