### PR TITLE
docs: layered usage documentation (OCI labels, AGENTS.md, consumer README, anti-pattern guards)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -51,6 +51,7 @@ jobs:
     environment: ghcr-publish
     outputs:
       version: ${{ steps.version.outputs.version }}
+      build_date: ${{ steps.meta.outputs.build_date }}
     steps:
       - name: Resolve version (tag → semver; manual dispatch → manual-build)
         id: version
@@ -66,6 +67,10 @@ jobs:
           else
             echo "version=manual-build" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Compute build metadata (single source of truth for all jobs)
+        id: meta
+        run: echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Approval recorded
         env:
@@ -109,9 +114,11 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/base:${{ needs.gate.outputs.version }}-canary
             ${{ env.IMAGE_PREFIX }}/base:nightly
+          # Dynamic OCI labels — statics live in the Dockerfile.
           labels: |
-            org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
             org.opencontainers.image.version=${{ needs.gate.outputs.version }}
+            org.opencontainers.image.created=${{ needs.gate.outputs.build_date }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
   # --- Build language images (depend on base for FROM, gate for version) -----
   languages:
@@ -163,9 +170,11 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ needs.gate.outputs.version }}-canary-${{ matrix.lang_version }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:nightly-${{ matrix.lang_version }}
+          # Dynamic OCI labels — statics live in the Dockerfile.
           labels: |
-            org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
             org.opencontainers.image.version=${{ needs.gate.outputs.version }}
+            org.opencontainers.image.created=${{ needs.gate.outputs.build_date }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
   # --- Build proxy image (independent of base — runs in parallel) ------------
   proxy:
@@ -194,9 +203,11 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/proxy:${{ needs.gate.outputs.version }}-canary
             ${{ env.IMAGE_PREFIX }}/proxy:nightly
+          # Dynamic OCI labels — statics live in the Dockerfile.
           labels: |
-            org.opencontainers.image.source=https://github.com/AndEnd-Collective/RunSecure
             org.opencontainers.image.version=${{ needs.gate.outputs.version }}
+            org.opencontainers.image.created=${{ needs.gate.outputs.build_date }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
   # --- Post-publish Grype scan: detects known CVEs in the base image ---------
   # Runs after base is published. Fails the workflow if HIGH/CRITICAL CVEs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Operating Principles for RunSecure
+
+For humans and LLMs working on this codebase. README.md tells you *what*; this tells you *why these things are not up for debate*.
+
+If you're an LLM proposing changes to this project, read this file first. The rules below come from incidents that already happened — re-litigating them produces the same incident again.
+
+---
+
+## Architecture decisions that are NOT up for re-litigation
+
+- **No permanent runner daemon.** Self-CI uses the one-shot `infra/scripts/dev/bootstrap-self-runner.sh` script, invoked on demand. A long-running orchestrator wrapper (`while true; do run.sh; sleep 10; done`) was tried, generated continuous `git-credential-manager` and polling noise, and was explicitly retired. Do not propose re-introducing it.
+- **Images are terminal.** Don't `FROM ghcr.io/.../runsecure/*` in user Dockerfiles to layer tools on top. The hardening (`apt` removed, root locked, setuid stripped, `/etc` 555) is final. Tools that consumers need go in `tools/*.sh` via the project's `runner.yml`, *before* `finalize-hardening.sh` runs.
+- **Versions bump weekly via `weekly-version-bump.yml`.** Don't tag manually unless re-cutting after a bug fix (and even then, prefer triggering `weekly-version-bump.yml` with `bump_type=patch` so the same machinery runs).
+- **One approval gate per release.** The `ghcr-publish` environment gates exactly one job (`gate`) in `publish-images.yml`. Don't add `environment: ghcr-publish` to additional jobs — that re-introduces the multi-prompt UX we already fixed.
+- **`apt-get upgrade -y` in every Dockerfile is load-bearing.** Without it, grype flags HIGH CVEs in unpatched debian:bookworm-slim packages even on a fresh digest. Don't remove it for "build speed."
+- **Python comes from `astral-sh/python-build-standalone`, not Debian.** Debian Bookworm's `python3` is 3.11.2; we ship 3.12. Pinned to a specific release tag + SHA256s per architecture. Adding a new minor version means one new case branch in `images/python.Dockerfile` plus the publish matrix entry.
+
+## Anti-patterns we've burned ourselves on
+
+- **Build-args that aren't referenced in the install step.** The `ARG PYTHON_VERSION=3.12` → ships 3.11.2 bug (fixed v1.1.5). Every language Dockerfile now has a build-time assertion comparing the installed runtime version to the build-arg. Don't remove those assertions; if you add a new language image, add the equivalent assertion.
+- **Broad `--ignore-cve` flags.** Never disable grype's `--fail-on high`. If a finding truly can't be fixed by us (because it's in an upstream-bundled binary), add a *specific* entry to `.grype.yaml` with: the CVE ID, the package, the upstream project, the version that ships the fix, and the trigger that means we can remove the entry. No blanket suppressions.
+- **Force-pushing main to "fix" things.** The repo went through a `git-filter-repo` rewrite (May 2026) to scrub Claude/cerebras.net trailers; that's the only legitimate use case. Day-to-day commits go via PRs.
+- **AI attribution in commits / PRs / authorship.** No `Co-Authored-By: Claude`, no `🤖 Generated with...` footers, no `cerebras.net` emails. The git history was scrubbed; new commits must not re-introduce it.
+- **GitHub `--no-verify` or hook bypasses.** Pre-push validation catches stuff that CI would otherwise reject. Fix the issue, don't skip the check.
+
+## When in doubt
+
+- Security model → `SECURITY.md` (claim catalog with severity, file references, and the acceptance check that verifies each)
+- Runtime behavior → `README.md` § "Operational notes"
+- Image consumption (tags, lifecycle, verification) → `README.md` § "Consuming RunSecure images"
+- Anything else → ask before changing.
+
+## For LLMs specifically
+
+- If a previous session left a redesign document, plan, or scratch file lying around, **verify the premise still holds** before acting on it. The system may have moved on (e.g., the daemon was retired; a "redesign drivers" document still treats it as live).
+- Don't propose a new abstraction to solve a problem you haven't reproduced. If grype is "blocking the build," check whether it's actually blocking *now*, not "would block if we approved the gate."
+- Read the relevant files end-to-end before editing. Symptoms-from-logs and grep snippets are not enough; bugs in this repo have hidden in unreferenced build-args, dead idempotency checks, and stale environment-mode flags.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,54 @@ SARIF is uploaded **always** (even when the workflow itself fails),
 so failures land in the Security tab even when the gating step
 re-raises the original exit code.
 
+## Consuming RunSecure images
+
+If you're operating RunSecure yourself, see [Self-hosting RunSecure](#self-hosting-runsecure-for-its-own-ci) below. **This section is for everyone whose CI pulls a RunSecure image off GHCR.** Two different audiences.
+
+### Tag scheme
+
+Images are at `ghcr.io/andend-collective/runsecure/<image>:<tag>`. Three tag styles:
+
+| Tag form | Example | What it points at | When to use |
+|---|---|---|---|
+| **Pinned** | `python:1.1.5-3.12` | One specific build, byte-identical forever | Production. Lock to a known-good build; bump deliberately. |
+| **Floating minor** | `python:1.1-3.12` | The latest patch of the 1.1.x line | Stable projects that want auto-patches but not breaking changes. (Tag is published only by promote-to-stable after acceptance.) |
+| **Rolling latest** | `python:latest-3.12` | Whatever the most recent successful release was | Local development, CI scratchpads. **Do not use in production** — a new release can silently change behavior under you. |
+| **Canary** | `python:1.1.5-canary-3.12` | The just-published, not-yet-acceptance-validated build | Don't pull this directly. It exists so the acceptance suite can test before promote. |
+
+The promotion is server-side via `docker buildx imagetools create` — `:1.1.5`, `:1.1`, and `:latest` are all the same digest as the canary that passed acceptance. No rebuild, no drift.
+
+### Verify what you pulled
+
+Every image carries OCI metadata. To see the source commit, build date, and version:
+
+```bash
+docker inspect ghcr.io/andend-collective/runsecure/python:1.1.5-3.12 \
+  | jq '.[0].Config.Labels | {
+      title: ."org.opencontainers.image.title",
+      version: ."org.opencontainers.image.version",
+      created: ."org.opencontainers.image.created",
+      revision: ."org.opencontainers.image.revision",
+      source: ."org.opencontainers.image.source"
+    }'
+```
+
+If `revision` doesn't match a commit on `main` of the source repo, the image isn't ours.
+
+### Lifecycle
+
+- A new patch release ships every Monday at 02:30 UTC (`weekly-version-bump.yml`).
+- Pinned tags (`:1.1.5`, `:1.1.5-3.12`, etc.) are **never moved**. Once published, the digest behind that tag is permanent.
+- Floating tags (`:1.1`, `:1.1-3.12`, `:latest`, `:latest-3.12`) move on every release.
+- We do not delete old pinned tags. Consumers can stay on an older pin indefinitely; security fixes only land in newer pins.
+
+### Anti-patterns — don't do this
+
+- **Don't `FROM` a RunSecure image** to add your own tooling. The hardening (`apt` removed, `/etc` read-only, setuid stripped, no shell for root) is designed to be terminal. Layering on top either breaks the hardening or breaks your install. If you need a tool, add it via the `tools:` block in your project's `runner.yml` so it's added before finalize-hardening runs.
+- **Don't run the container with `--user 0` or `--cap-add`.** The image is designed to run as UID 1001 with `cap_drop: ALL`. Re-adding privileges defeats every claim in SECURITY.md.
+- **Don't pull `:latest` in production.** It moves silently. Pin to `:X.Y.Z[-langver]` and bump deliberately.
+- **Don't reuse a container across jobs.** The whole security model relies on `--rm` after every job. If you need warm caches, use volume mounts for the cache directory, not container reuse.
+
 ## Self-hosting RunSecure for its own CI
 
 The repo dogfoods its own runner. The `dogfood.yml` workflow runs the

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -41,11 +41,18 @@ ARG GH_CLI_SHA256_ARM64=34d620b7c884774ed86236541535170889fda0b99aafbdab8b69c7d4
 
 ARG TARGETARCH
 
-# ---- Labels -----------------------------------------------------------------
+# ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
+# Standard OCI labels surface in `docker inspect`, GHCR's package page
+# (description is auto-promoted), and most container security scanners.
+# `documentation` is the single canonical pointer for consumers asking
+# "what is this and how am I supposed to use it".
 LABEL org.opencontainers.image.title="RunSecure Base"
-LABEL org.opencontainers.image.description="Hardened GitHub Actions self-hosted runner base image"
-LABEL org.opencontainers.image.source="https://github.com/NaorPenso/RunSecure"
-LABEL org.opencontainers.image.vendor="RunSecure"
+LABEL org.opencontainers.image.description="Hardened ephemeral GitHub Actions self-hosted runner base image. One job per container, then destroyed. See documentation for proper usage."
+LABEL org.opencontainers.image.source="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.documentation="https://github.com/AndEnd-Collective/RunSecure#consuming-runsecure-images"
+LABEL org.opencontainers.image.url="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="AndEnd Collective"
 LABEL security.hardening="full"
 
 # ---- System dependencies ----------------------------------------------------

--- a/images/node.Dockerfile
+++ b/images/node.Dockerfile
@@ -16,6 +16,16 @@ FROM ${BASE_IMAGE}:${BASE_TAG} AS node
 
 ARG NODE_VERSION=24
 
+# ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
+LABEL org.opencontainers.image.title="RunSecure Node.js"
+LABEL org.opencontainers.image.description="Hardened ephemeral GitHub Actions runner with Node.js. One job per container, then destroyed. See documentation for proper usage."
+LABEL org.opencontainers.image.source="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.documentation="https://github.com/AndEnd-Collective/RunSecure#consuming-runsecure-images"
+LABEL org.opencontainers.image.url="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="AndEnd Collective"
+LABEL security.hardening="full"
+
 USER root
 
 # Install Node.js from NodeSource using GPG-verified apt repo (no pipe-to-bash).

--- a/images/python.Dockerfile
+++ b/images/python.Dockerfile
@@ -29,6 +29,16 @@ FROM ${BASE_IMAGE}:${BASE_TAG} AS python
 
 ARG PYTHON_VERSION=3.12
 
+# ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
+LABEL org.opencontainers.image.title="RunSecure Python"
+LABEL org.opencontainers.image.description="Hardened ephemeral GitHub Actions runner with Python (astral-sh/python-build-standalone, SHA256-verified). One job per container, then destroyed. See documentation for proper usage."
+LABEL org.opencontainers.image.source="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.documentation="https://github.com/AndEnd-Collective/RunSecure#consuming-runsecure-images"
+LABEL org.opencontainers.image.url="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="AndEnd Collective"
+LABEL security.hardening="full"
+
 USER root
 
 # `apt-get upgrade` pulls latest security patches; no Python packages from

--- a/images/rust.Dockerfile
+++ b/images/rust.Dockerfile
@@ -16,6 +16,16 @@ FROM ${BASE_IMAGE}:${BASE_TAG} AS rust
 
 ARG RUST_VERSION=stable
 
+# ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
+LABEL org.opencontainers.image.title="RunSecure Rust"
+LABEL org.opencontainers.image.description="Hardened ephemeral GitHub Actions runner with Rust toolchain. One job per container, then destroyed. See documentation for proper usage."
+LABEL org.opencontainers.image.source="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.documentation="https://github.com/AndEnd-Collective/RunSecure#consuming-runsecure-images"
+LABEL org.opencontainers.image.url="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="AndEnd Collective"
+LABEL security.hardening="full"
+
 USER root
 
 # Rust needs a linker and basic build tools.

--- a/infra/scripts/run.sh
+++ b/infra/scripts/run.sh
@@ -12,6 +12,19 @@
 #   ./infra/scripts/run.sh --project /path/to/project --repo owner/repo
 #   ./infra/scripts/run.sh --project /path/to/project --repo owner/repo --max-jobs 5
 #
+# Invocation patterns — preferred to direct:
+#   1. Self-CI on this repo:
+#        infra/scripts/dev/bootstrap-self-runner.sh [N]
+#      (handles project + repo + sensible max-jobs default; exits when drained)
+#   2. One-shot for any other repo: invoke directly with --project + --repo
+#
+# DO NOT wrap this in `while true; do ...; sleep N; done`. The script
+# already processes --max-jobs ephemeral runners and exits cleanly. A
+# wrapper loop re-introduces the credential-helper noise + polling
+# pathology that caused the daemon-style orchestrator to be retired.
+# If you need continuous availability, set --max-jobs higher and invoke
+# once. See AGENTS.md "Architecture decisions" for context.
+#
 # Prerequisites:
 #   - Docker
 #   - gh CLI (authenticated)

--- a/infra/squid/Dockerfile
+++ b/infra/squid/Dockerfile
@@ -12,6 +12,15 @@
 
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 
+# ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
+LABEL org.opencontainers.image.title="RunSecure Egress Proxy"
+LABEL org.opencontainers.image.description="Multi-protocol egress filter (Squid HTTP/HTTPS + HAProxy TCP + dnsmasq DNS) used by RunSecure runner containers to enforce a per-project allowlist."
+LABEL org.opencontainers.image.source="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.documentation="https://github.com/AndEnd-Collective/RunSecure#consuming-runsecure-images"
+LABEL org.opencontainers.image.url="https://github.com/AndEnd-Collective/RunSecure"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="AndEnd Collective"
+
 # `apt-get upgrade` pulls latest security patches for the base layer. Without
 # this, grype flags HIGH CVEs in unpatched debian:bookworm-slim packages
 # (libc6, libsystemd0, libcap2, etc) even on a fresh digest, because Debian


### PR DESCRIPTION
## Summary

Five-layer pass to make proper usage patterns durable for both humans and LLMs touching this codebase. No behavior change — only labels, comments, and READMEs.

## What changes

| Layer | Change | Audience |
|---|---|---|
| 1. **OCI labels** | Full static label block on all 5 Dockerfiles (base, node, python, rust, proxy); dynamic labels (created, revision, version) wired via gate-job output in publish-images.yml | Anyone running \`docker inspect\` or visiting the GHCR package page |
| 2. **README "Consuming RunSecure images"** | New section: tag scheme (pinned / floating-minor / rolling-latest / canary), verification via labels, lifecycle, explicit anti-patterns (don't FROM, don't \`:latest\` in prod, don't reuse containers) | Project teams whose CI pulls these images |
| 3. **AGENTS.md** | New root-level file listing architecture decisions not up for re-litigation + anti-patterns already burned in past sessions | Future humans + LLMs working on this repo |
| 4. **Dead-code stale markers** (outside this repo) | DISABLED banners on \`~/Code/datacenteric/scripts/runners/\` files + the launchd plist, pointing at \`bootstrap-self-runner.sh\` | Anyone (or any LLM) tempted to re-enable the retired daemon |
| 5. **\`run.sh\` invocation header** | New comment block listing preferred patterns and explicitly forbidding \`while true; do ...; sleep N; done\` wrapping | Anyone editing or invoking \`run.sh\` |

## Why now

Caught several risk areas in recent sessions:
- A "redesign drivers" document treating the retired daemon as live → AGENTS.md's "not up for re-litigation" list prevents this
- The Python-3.12-actually-3.11 bug shipped for months unnoticed → both the build-time assertion (#38) and AGENTS.md's anti-pattern entry prevent recurrence
- GHCR package pages had no description because only \`base.Dockerfile\` had labels → all 5 now do

## Test plan

- [ ] CI on this PR passes (no functional changes; \`validate.yml\` should be green)
- [ ] Next release builds with new labels — verify via:
  \`\`\`bash
  docker pull ghcr.io/andend-collective/runsecure/python:latest-3.12
  docker inspect ghcr.io/andend-collective/runsecure/python:latest-3.12 \\
    | jq '.[0].Config.Labels'
  \`\`\`
  Expected: 11 labels including \`org.opencontainers.image.{title,description,source,documentation,url,licenses,vendor,version,created,revision}\` + \`security.hardening\`
- [ ] GHCR package page for \`runsecure/python\` shows the description after next release (auto-promoted by GHCR from the OCI \`description\` label)