### PR TITLE
chore(deps): refresh version pins to latest stable + consistency fixes

### DIFF
--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always() && hashFiles('grype-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           sarif_file: grype-results.sarif
           category: 'grype-${{ matrix.image_name }}'

--- a/.github/workflows/post-publish-acceptance.yml
+++ b/.github/workflows/post-publish-acceptance.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always() && hashFiles('tests/acceptance/_sarif/acceptance-*.sarif') != ''
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           sarif_file: tests/acceptance/_sarif/
           category: "acceptance-${{ matrix.lang }}-${{ matrix.lang_version }}"

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -119,9 +119,9 @@ jobs:
       ALIAS: ${{ matrix.also_alias }}
       REPO: ghcr.io/andend-collective/runsecure
     steps:
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -90,15 +90,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: images/base.Dockerfile
@@ -149,15 +149,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ matrix.file }}
@@ -186,15 +186,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: infra/squid
           file: infra/squid/Dockerfile
@@ -221,13 +221,13 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: infra/orchestrator
           file: infra/orchestrator/Dockerfile
@@ -250,13 +250,13 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: infra/socket-proxy
           file: infra/socket-proxy/Dockerfile
@@ -288,7 +288,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -320,7 +320,7 @@ jobs:
 
       - name: Upload Grype scan results (base) to GitHub Security
         if: always() && hashFiles('grype-base.sarif') != ''
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           sarif_file: grype-base.sarif
           category: grype-base
@@ -335,7 +335,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -363,7 +363,7 @@ jobs:
 
       - name: Upload Grype scan results (proxy) to GitHub Security
         if: always() && hashFiles('grype-proxy.sarif') != ''
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           sarif_file: grype-proxy.sarif
           category: grype-proxy

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
       - name: Build + test
@@ -131,7 +131,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
       - name: Build + test
@@ -158,7 +158,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
       - name: Build corner-lint (vendored at tools/corner-lint)

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -21,7 +21,7 @@
 #  15.  Multi-stage ready (used as FROM target)
 # ============================================================================
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS base
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS base
 
 # ---- Build arguments --------------------------------------------------------
 # All pins follow a 48-hour freshness rule: the chosen version must be at
@@ -34,10 +34,10 @@ FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5
 ARG RUNNER_VERSION=2.334.0
 ARG RUNNER_SHA256_ARM64=f44255bd3e80160eb25f71bc83d06ea025f6908748807a584687b3184759f7e4
 ARG RUNNER_SHA256_AMD64=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
-# GH_CLI_VERSION 2.92.0 (2026-04-28) — current latest stable.
-ARG GH_CLI_VERSION=2.92.0
-ARG GH_CLI_SHA256_AMD64=8f8212b1a9cec261a8839e0893168f50d3fc70f095da257feef4229234cefdf8
-ARG GH_CLI_SHA256_ARM64=34d620b7c884774ed86236541535170889fda0b99aafbdab8b69c7d458b5ca6b
+# GH_CLI_VERSION 2.93.0 (2026-05-27) — current latest stable.
+ARG GH_CLI_VERSION=2.93.0
+ARG GH_CLI_SHA256_AMD64=5371f77155e5dd81b6e897c379431f734949b99b99ae1f01c5e3ab6d3795cf4d
+ARG GH_CLI_SHA256_ARM64=ac30768545cc31bbef9ffef27d2f2218b2739375019883b8095acf2f734e7b7f
 
 ARG TARGETARCH
 

--- a/infra/orchestrator/Dockerfile
+++ b/infra/orchestrator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN CGO_ENABLED=0 \
     go build -trimpath -ldflags='-s -w' -o /out/orchestrator ./cmd/orchestrator
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 COPY --from=build /out/orchestrator /usr/local/bin/orchestrator
 USER nonroot:nonroot
 HEALTHCHECK --interval=15s --timeout=2s --retries=3 \

--- a/infra/socket-proxy/Dockerfile
+++ b/infra/socket-proxy/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 \
     go build -trimpath -ldflags='-s -w' \
     -o /out/socket-proxy ./cmd/socket-proxy
 
-FROM gcr.io/distroless/static-debian12:latest
+FROM gcr.io/distroless/static-debian12:latest@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
 COPY --from=build /out/socket-proxy /usr/local/bin/socket-proxy
 COPY allowed-images.txt /etc/runsecure/socket-proxy/allowed-images.txt
 # Runs as root by necessity: /var/run/docker.sock on Docker Desktop / Colima

--- a/infra/squid/Dockerfile
+++ b/infra/squid/Dockerfile
@@ -10,7 +10,7 @@
 # monitors them. Exits non-zero if Squid exits non-zero.
 # ============================================================================
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
 # ---- OCI labels (static — dynamic ones added by publish-images.yml) --------
 LABEL org.opencontainers.image.title="RunSecure Egress Proxy"

--- a/tools/corner-lint/go.mod
+++ b/tools/corner-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/Cerebras/Cornerstone/corner-lint
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## What

Routine maintenance pass — refresh source-level version pins to latest stable and fix two consistency drifts. No behavior change.

### Version-pin refresh
The `weekly-version-bump` workflow only bumps the *release tag* (triggering a no-cache rebuild that picks up Debian package updates); it does **not** touch these source pins, so they're refreshed manually here.

- `debian:bookworm-slim` digest `67b30a61…` → `0104b334…` (`base.Dockerfile` + `squid/Dockerfile`)
- gh CLI `2.92.0` → `2.93.0` (refreshed amd64/arm64 `.deb` checksums)
- `actions/setup-go` `v6.0.0` → `v6.4.0`
- `docker/login-action` `v4.1.0` → `v4.2.0`
- `docker/setup-buildx-action` `v4.0.0` → `v4.1.0`
- `docker/build-push-action` `v7.1.0` → `v7.2.0`
- `github/codeql-action` `v4.35.5` → `v4.36.0`

### Consistency fixes
- `tools/corner-lint/go.mod` `go 1.25.0` → `1.26.3` (match orchestrator/socket-proxy modules)
- Digest-pin both distroless bases (orchestrator `:nonroot`, socket-proxy `:latest`) to match the existing debian digest-pin convention — reproducible builds. socket-proxy keeps the root-capable `:latest` variant by design (reads root-owned `docker.sock`).

### Left unchanged (already latest / out of scope)
- `actions-runner` 2.334.0, Go 1.26.3, `actions/checkout` v6.0.2, Node LTS 24 — already latest stable
- Python kept at 3.12: its `3.12.13` patch is current; changing the default minor is a support-matrix decision (would drop 3.12 for consumers), not a pin refresh

## Verification (local)
- Base image builds with new pins — `gh version 2.93.0` confirmed in-image, so the Dockerfile `sha256sum -c` checksum gate accepted the new gh + debian pins
- `corner-lint` builds + runs on the bumped `go 1.26.3` directive
- `test-workflow-yaml-valid.sh` passes (covers all action-SHA edits)
- A transient `test-tool-recipes.sh` playwright failure was traced to a stale local Docker cache layer; a clean `--no-cache` rebuild passes (`Version 1.60.0`)