### PR TITLE
ci(publish): Grype-scan orchestrator + socket-proxy images (close 2.0.0 scan gap)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -367,3 +367,93 @@ jobs:
         with:
           sarif_file: grype-proxy.sarif
           category: grype-proxy
+
+  # --- Post-publish Grype scan: orchestrator image (distroless Go binary) -----
+  # The orchestrator is a long-running control-plane binary; CVEs in its Go
+  # stdlib/modules (as the gh-stdlib findings showed) must gate the publish.
+  grype-scan-orchestrator:
+    needs: [gate, orchestrator]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Grype (latest, fresh CVE DB)
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+            | sh -s -- -b /usr/local/bin
+          grype version
+
+      - name: Grype scan (orchestrator image) — fail on HIGH/CRITICAL with fix
+        env:
+          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/orchestrator:${{ needs.gate.outputs.version }}-canary"
+        run: |
+          set -euo pipefail
+          grype "$IMAGE_REF" --output table --fail-on high --only-fixed \
+            || GRYPE_FAILED=1
+          grype "$IMAGE_REF" --output sarif --file grype-orchestrator.sarif --only-fixed
+          if [ "${GRYPE_FAILED:-0}" = "1" ]; then
+            echo "::error::Grype found HIGH/CRITICAL vulnerabilities with available fixes in $IMAGE_REF"
+            exit 1
+          fi
+
+      - name: Upload Grype scan results (orchestrator) to GitHub Security
+        if: always() && hashFiles('grype-orchestrator.sarif') != ''
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
+        with:
+          sarif_file: grype-orchestrator.sarif
+          category: grype-orchestrator
+
+  # --- Post-publish Grype scan: socket-proxy image (distroless Go binary) -----
+  # socket-proxy is the only component mounting docker.sock; its binary must be
+  # CVE-gated like every other published image.
+  grype-scan-socket-proxy:
+    needs: [gate, socket-proxy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Grype (latest, fresh CVE DB)
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+            | sh -s -- -b /usr/local/bin
+          grype version
+
+      - name: Grype scan (socket-proxy image) — fail on HIGH/CRITICAL with fix
+        env:
+          IMAGE_REF: "${{ env.IMAGE_PREFIX }}/socket-proxy:${{ needs.gate.outputs.version }}-canary"
+        run: |
+          set -euo pipefail
+          grype "$IMAGE_REF" --output table --fail-on high --only-fixed \
+            || GRYPE_FAILED=1
+          grype "$IMAGE_REF" --output sarif --file grype-socket-proxy.sarif --only-fixed
+          if [ "${GRYPE_FAILED:-0}" = "1" ]; then
+            echo "::error::Grype found HIGH/CRITICAL vulnerabilities with available fixes in $IMAGE_REF"
+            exit 1
+          fi
+
+      - name: Upload Grype scan results (socket-proxy) to GitHub Security
+        if: always() && hashFiles('grype-socket-proxy.sarif') != ''
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
+        with:
+          sarif_file: grype-socket-proxy.sarif
+          category: grype-socket-proxy

--- a/tests/validation/test-cve-scanner-config.sh
+++ b/tests/validation/test-cve-scanner-config.sh
@@ -82,6 +82,19 @@ if [[ -f "$PUBLISH_WF" ]]; then
     else
         pass "publish-images.yml: no stale anchore/scan-action wrapper"
     fi
+
+    # --- Every published image must have a post-publish Grype scan ----------
+    # Each image-pushing job (base, proxy, orchestrator, socket-proxy) builds a
+    # distinct GHCR image; each MUST be CVE-gated. This caught the 2.0.0 gap
+    # where orchestrator + socket-proxy shipped unscanned. If you add a new
+    # published image, add a grype-scan-<image> job AND list it here.
+    for img in base proxy orchestrator socket-proxy; do
+        if grep -qE "IMAGE_REF:.*/${img}:" "$PUBLISH_WF"; then
+            pass "publish-images.yml: ${img} image has a post-publish Grype scan"
+        else
+            fail "publish-images.yml: ${img} image is published but NOT Grype-scanned"
+        fi
+    done
 fi
 
 # --- Print results ----------------------------------------------------------


### PR DESCRIPTION
## Problem
`publish-images.yml` ran post-publish Grype scans only on **base** and **proxy**. The **orchestrator** and **socket-proxy** images — both new in 2.0.0 (distroless Go binaries) — were built and pushed to GHCR **without any CVE scan**. Go binaries do carry CVEs (cf. the gh go-stdlib HIGHs that blocked 1.1.9), so for a security product these must gate the publish.

## Fix
- Add `grype-scan-orchestrator` and `grype-scan-socket-proxy` jobs, mirroring `grype-scan-proxy` (install grype directly, `--fail-on high --only-fixed`, SARIF upload to the Security tab).
- Add a coverage assertion in `tests/validation/test-cve-scanner-config.sh`: every published image (`base`, `proxy`, `orchestrator`, `socket-proxy`) MUST have a post-publish Grype scan — so a future published image can't silently ship unscanned.

## Verification
- `tests/validation/test-cve-scanner-config.sh` → 13/13 (the 4 new coverage checks pass).
- `tests/validation/test-workflow-yaml-valid.sh` → pass.

After merge, **2.0.0 will be re-cut** so the release itself ships with all four images CVE-gated.