### PR TITLE
fix(release): promote orchestrator + socket-proxy to stable tags

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -95,6 +95,17 @@ jobs:
             canary_tag: '${{ needs.resolve-version.outputs.version }}-canary'
             stable_tag: '${{ needs.resolve-version.outputs.version }}'
             also_alias: latest
+          # Control-plane images (orchestrator + socket-proxy) — same retag
+          # shape as base/proxy. Previously omitted, so they were stuck at
+          # <ver>-canary and never got the stable <ver>/latest tags.
+          - kind: orchestrator
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary'
+            stable_tag: '${{ needs.resolve-version.outputs.version }}'
+            also_alias: latest
+          - kind: socket-proxy
+            canary_tag: '${{ needs.resolve-version.outputs.version }}-canary'
+            stable_tag: '${{ needs.resolve-version.outputs.version }}'
+            also_alias: latest
           # Language images: <ver>-canary-<langver> → <ver>-<langver>, nightly-<langver> → latest-<langver>
           - kind: node
             canary_tag: '${{ needs.resolve-version.outputs.version }}-canary-24'

--- a/tests/validation/test-promote-coverage.sh
+++ b/tests/validation/test-promote-coverage.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# ============================================================================
+# RunSecure — Promote-to-Stable Coverage Lint
+# ============================================================================
+# Asserts every published image kind has a promote-to-stable matrix entry, so
+# an image can't be built + Grype-scanned + pushed as `<ver>-canary` yet never
+# promoted to the stable `<ver>` / `latest` tags.
+#
+# This guards the exact regression where the orchestrator + socket-proxy
+# control-plane images were omitted from promote-to-stable's matrix (they were
+# added to publish-images for the Compose-backed orchestrator, but the promote
+# matrix was never updated), leaving operators with only `-canary` tags.
+#
+# Pure file-content check — no Docker required.
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNSECURE_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKFLOWS_DIR="${RUNSECURE_ROOT}/.github/workflows"
+PROMOTE_WF="${WORKFLOWS_DIR}/promote-to-stable.yml"
+
+PASS=0
+FAIL=0
+RESULTS=()
+pass() { RESULTS+=("PASS: $1"); PASS=$((PASS + 1)); }
+fail() { RESULTS+=("FAIL: $1"); FAIL=$((FAIL + 1)); }
+
+if [[ ! -f "$PROMOTE_WF" ]]; then
+    echo "FAILED: promote-to-stable.yml not found at $PROMOTE_WF"
+    exit 1
+fi
+
+# Every image kind that publish-images builds + pushes must have at least one
+# `kind: <name>` entry in the promote-to-stable matrix. If you add a new
+# published image, add it to promote-to-stable.yml AND list it here.
+for img in base proxy orchestrator socket-proxy node python rust; do
+    if grep -qE "^[[:space:]]*-?[[:space:]]*kind:[[:space:]]*${img}\b" "$PROMOTE_WF"; then
+        pass "promote-to-stable.yml: '${img}' image is promoted canary→stable"
+    else
+        fail "promote-to-stable.yml: '${img}' image is published but NOT promoted (stuck at -canary)"
+    fi
+done
+
+echo ""
+echo "=== Promote-to-Stable Coverage ==="
+for r in "${RESULTS[@]}"; do
+    echo "  $r"
+done
+echo ""
+if [[ $FAIL -gt 0 ]]; then
+    echo "FAILED: $PASS passed, $FAIL failed"
+    exit 1
+else
+    echo "PASSED: $PASS tests"
+    exit 0
+fi


### PR DESCRIPTION
## Problem
`promote-to-stable.yml` retags only `base`, `proxy`, `node`, `python`, `rust` from `<ver>-canary` to the stable `<ver>`/`latest` tags. The **orchestrator** and **socket-proxy** control-plane images — built, Grype-scanned, and pushed as `<ver>-canary` by `publish-images` — were never promoted, so they're stuck at `-canary` with no `<ver>` or `latest` tag. Surfaced on the 2.1.0 release: `orchestrator:2.1.0`/`latest` and `socket-proxy:2.1.0`/`latest` don't exist, while `base:2.1.0` and `proxy:2.1.0` do.

## Fix
- Add `orchestrator` + `socket-proxy` to the promote matrix (same canary→stable→latest shape as base/proxy).
- Add `tests/validation/test-promote-coverage.sh` asserting every published image kind has a promote entry — same regression-guard pattern as the Grype-scan coverage test (#46). 7/7 pass.

## After merge
Re-run promote-to-stable for **v2.1.0** to retag the existing `2.1.0-canary` control-plane digests (`orchestrator@585027b5`, `socket-proxy@7334847e`) to `2.1.0` + `latest`. No rebuild — server-side retag of the already-gated digests.