### PR TITLE
chore(chart): pin real 2.1.0 image digests

### DIFF
--- a/charts/runsecure-orchestrator/values.yaml
+++ b/charts/runsecure-orchestrator/values.yaml
@@ -12,17 +12,17 @@ image:
   orchestrator:
     repository: ghcr.io/andend-collective/runsecure/orchestrator
     tag: "2.1.0"
-    digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    digest: "sha256:5f88ad8608510c089dc5011e3a2fbe014f2e6256cdcfdfda938c3b676cb969ab"
     pullPolicy: Always
   proxy:
     repository: ghcr.io/andend-collective/runsecure/proxy
     tag: "2.1.0"
-    digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    digest: "sha256:8d6eab73932cd6e13cc1f25bfa250ecb0aad6cc891754018d1be9266a0f11c32"
     pullPolicy: Always
   socketProxy:
     repository: ghcr.io/andend-collective/runsecure/socket-proxy
     tag: "2.1.0"
-    digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    digest: "sha256:44b5d07f0ef7f2c7e6121110a392d23288ec7676ee106779c32af98d67d5d866"
     pullPolicy: Always
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fills the placeholder image digests in `charts/runsecure-orchestrator/values.yaml` with the real promoted 2.1.0 GHCR manifest digests:

- orchestrator `@sha256:5f88ad86…`
- proxy `@sha256:8d6eab73…`
- socket-proxy `@sha256:44b5d07f…`

helm lint + kubeconform + CIS/PSS chart assertions pass; no placeholder digests remain.