### PR TITLE
fix: compose-backend orchestrator bring-up blockers (#54)

### DIFF
--- a/infra/orchestrator/cmd/orchestrator/run.go
+++ b/infra/orchestrator/cmd/orchestrator/run.go
@@ -72,6 +72,17 @@ func Run(ctx context.Context, scopePath string) error {
 		}
 	}
 
+	// Cold-start per-spawn network cleanup (#54 fix 4): remove any rs-net-*
+	// networks from a previous orchestrator run. These are created per-spawn and
+	// normally deleted by Teardown, but a hard restart or crash leaves them
+	// behind. The address-pool exhausts after ~31 unreleased bridge networks.
+	// We list only runsecure.scope-labelled networks so the scope is precise.
+	if nets, err := dc.ListNetworksForScope(ctx, s.Name); err == nil {
+		for _, n := range nets {
+			_ = dc.DeleteNetwork(ctx, n.ID)
+		}
+	}
+
 	// Build everything the poll + spawn deps need.
 	intentCh := make(chan orchestrator.SpawnIntent, 32)
 	// B1 rate limiter — token bucket protecting against unbounded burst.

--- a/infra/orchestrator/compose.scope.yml
+++ b/infra/orchestrator/compose.scope.yml
@@ -31,6 +31,14 @@ services:
       RUNSECURE_EGRESS_NETWORK: ${RUNSECURE_SCOPE}-spawn-egress
       # Egress-volume gate: only role=proxy may mount this named volume.
       RUNSECURE_EGRESS_VOLUME: ${RUNSECURE_SCOPE}-egress-configs
+      # Optional: operator-supplied extra allowlist for release-specific digests.
+      # At release time the newly-published image digests are not yet baked into
+      # the socket-proxy image (bootstrap problem, #54 fix 3). Mount a file with
+      # the release digest(s) and set this env var to its container path:
+      #   RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE: /run/secrets/extra-images.txt
+      # with a corresponding volume entry pointing at the host file:
+      #   - /path/to/extra-images.txt:/run/secrets/extra-images.txt:ro
+      # The file must follow the same digest-reference format as allowed-images.txt.
 
   orch-egress:
     image: ${RUNSECURE_PROXY_IMAGE}

--- a/infra/orchestrator/compose.scope.yml
+++ b/infra/orchestrator/compose.scope.yml
@@ -39,8 +39,32 @@ services:
     read_only: true
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
+    # Run as the runsecure non-root user (UID 1001) — matches the USER in
+    # infra/squid/Dockerfile and the uid= in the tmpfs mounts below.
+    user: "1001:1001"
+    # Squid needs three writable runtime dirs even on a read-only rootfs.
+    # The proxy image creates these dirs with chown 1001:1001 during build
+    # (see infra/squid/Dockerfile), but read_only: true means the overlay
+    # is immutable — squid fatals on the pidfile write without writable tmpfs.
+    # Per-spawn proxies get these via docker.Spawn's HostConfig.Tmpfs map;
+    # this service (orch-egress) is brought up by compose directly and was
+    # missing the equivalent mounts, causing crash-loops (#54 fix 1).
+    # uid=1001 matches the runsecure user the image runs as; mode=750 matches
+    # the chown in the Dockerfile so squid's non-root process can write.
+    tmpfs:
+      - /var/run/squid:noexec,nosuid,nodev,uid=1001,gid=1001,mode=750
+      - /var/log/squid:noexec,nosuid,nodev,uid=1001,gid=1001,mode=750
+      - /var/spool/squid:noexec,nosuid,nodev,uid=1001,gid=1001,mode=750
     networks:
       orch-internal:
+      # Attach orch-egress to spawn-egress so compose creates this network
+      # at stack bring-up time. Per-spawn proxies join at runtime; without
+      # this attachment compose never creates the network and every spawn
+      # fails with "network not found" (#54 fix 2). Attaching orch-egress
+      # does NOT give runners or the orchestrator access to spawn-egress —
+      # runners only see the per-spawn internal network; the orchestrator
+      # only sees orch-internal. Spawn isolation is preserved.
+      spawn-egress:
       orch-external:
 
   egress-init:

--- a/infra/orchestrator/internal/backend/compose/compose_test.go
+++ b/infra/orchestrator/internal/backend/compose/compose_test.go
@@ -114,6 +114,10 @@ func (f *fakeDocker) ListContainersForScope(_ context.Context, _ string) ([]dock
 	return f.listResult, f.listErr
 }
 
+func (f *fakeDocker) ListNetworksForScope(_ context.Context, _ string) ([]docker.Network, error) {
+	return nil, nil
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -289,6 +293,10 @@ func (f *failNetworkDocker) DeleteContainer(ctx context.Context, id string, forc
 }
 func (f *failNetworkDocker) ListContainersForScope(ctx context.Context, scope string) ([]docker.Container, error) {
 	return f.inner.ListContainersForScope(ctx, scope)
+}
+
+func (f *failNetworkDocker) ListNetworksForScope(ctx context.Context, scope string) ([]docker.Network, error) {
+	return f.inner.ListNetworksForScope(ctx, scope)
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/orchestrator/internal/docker/client.go
+++ b/infra/orchestrator/internal/docker/client.go
@@ -37,6 +37,17 @@ type Client interface {
 	CreateNetwork(ctx context.Context, req CreateNetworkRequest) (id string, err error)
 	DeleteNetwork(ctx context.Context, id string) error
 	ListContainersForScope(ctx context.Context, scope string) ([]Container, error)
+	// ListNetworksForScope returns all Docker networks carrying
+	// runsecure.scope=<scope> in their Labels. Used at cold-start to clean up
+	// per-spawn networks left from a previous orchestrator run (#54 fix 4).
+	ListNetworksForScope(ctx context.Context, scope string) ([]Network, error)
+}
+
+// Network is a minimal representation of a Docker network.
+type Network struct {
+	ID     string
+	Name   string
+	Labels map[string]string
 }
 
 type CreateContainerRequest struct {
@@ -347,6 +358,39 @@ func (c *httpClient) ListContainersForScope(ctx context.Context, scope string) (
 			name = strings.TrimPrefix(cj.Names[0], "/")
 		}
 		out = append(out, Container{ID: cj.ID, Name: name, Labels: cj.Labels})
+	}
+	return out, nil
+}
+
+type networkJSON struct {
+	ID     string            `json:"Id"`
+	Name   string            `json:"Name"`
+	Labels map[string]string `json:"Labels"`
+}
+
+// ListNetworksForScope lists Docker networks whose runsecure.scope label
+// matches scope. Used at cold-start to delete per-spawn internal networks
+// (rs-net-<repo>-<spawnID>) that were not torn down before the previous
+// orchestrator restart (#54 fix 4).
+func (c *httpClient) ListNetworksForScope(ctx context.Context, scope string) ([]Network, error) {
+	filter := fmt.Sprintf(`{"label":["runsecure.scope=%s"]}`, scope)
+	path := "/networks?filters=" + url.QueryEscape(filter)
+	resp, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("docker: networks: status %d: %s", resp.StatusCode, string(b))
+	}
+	var arr []networkJSON
+	if err := json.NewDecoder(resp.Body).Decode(&arr); err != nil {
+		return nil, err
+	}
+	out := make([]Network, 0, len(arr))
+	for _, nj := range arr {
+		out = append(out, Network{ID: nj.ID, Name: nj.Name, Labels: nj.Labels})
 	}
 	return out, nil
 }

--- a/infra/orchestrator/internal/docker/client_test.go
+++ b/infra/orchestrator/internal/docker/client_test.go
@@ -605,3 +605,63 @@ func TestNewClient_HTTP_PlaintextUnchanged(t *testing.T) {
 	err := c.StartContainer(context.Background(), "abc")
 	require.NoError(t, err)
 }
+
+// ─── ListNetworksForScope tests (issue #54 fix 4) ────────────────────────────
+
+func TestListNetworksForScope_HappyPath(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1.44/networks", r.URL.Path)
+		q, _ := url.QueryUnescape(r.URL.RawQuery)
+		require.Contains(t, q, "runsecure.scope=test")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"Id":     "net-abc123",
+				"Name":   "rs-net-owner_repo-sp1",
+				"Labels": map[string]string{"runsecure.scope": "test", "runsecure.spawn_id": "sp1"},
+			},
+		})
+	})
+	nets, err := c.ListNetworksForScope(context.Background(), "test")
+	require.NoError(t, err)
+	require.Len(t, nets, 1)
+	require.Equal(t, "net-abc123", nets[0].ID)
+	require.Equal(t, "rs-net-owner_repo-sp1", nets[0].Name)
+	require.Equal(t, "test", nets[0].Labels["runsecure.scope"])
+}
+
+func TestListNetworksForScope_EmptyResult(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	nets, err := c.ListNetworksForScope(context.Background(), "test")
+	require.NoError(t, err)
+	require.Empty(t, nets)
+}
+
+func TestListNetworksForScope_500(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	_, err := c.ListNetworksForScope(context.Background(), "test")
+	require.Error(t, err)
+}
+
+func TestListNetworksForScope_MalformedResponse(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not json"))
+	})
+	_, err := c.ListNetworksForScope(context.Background(), "test")
+	require.Error(t, err)
+}
+
+// TestDo_NetworkError_ListNetworks verifies that ListNetworksForScope also
+// propagates transport-level errors (regression guard for the new method).
+func TestDo_NetworkError_ListNetworks(t *testing.T) {
+	c, err := NewClient("http://127.0.0.1:1")
+	require.NoError(t, err)
+	_, err = c.ListNetworksForScope(context.Background(), "s")
+	require.Error(t, err)
+}

--- a/infra/orchestrator/internal/docker/spawn_test.go
+++ b/infra/orchestrator/internal/docker/spawn_test.go
@@ -57,6 +57,10 @@ func (f *fakeClient) ListContainersForScope(_ context.Context, _ string) ([]Cont
 	return nil, nil
 }
 
+func (f *fakeClient) ListNetworksForScope(_ context.Context, _ string) ([]Network, error) {
+	return nil, nil
+}
+
 // hasEnv reports whether kv (e.g. "HTTP_PROXY=http://proxy:3128") is present
 // in the env slice.
 func hasEnv(env []string, kv string) bool {

--- a/infra/orchestrator/internal/egress/squid.go
+++ b/infra/orchestrator/internal/egress/squid.go
@@ -19,6 +19,29 @@ var reDomain = regexp.MustCompile(`^\.?[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$`
 // any other character that could inject a second squid directive.
 var reCIDR = regexp.MustCompile(`^[0-9a-fA-F:.]+/[0-9]{1,3}$`)
 
+// GitHubCoreDomains is the set of domains the GitHub Actions control-plane
+// requires for every runner — regardless of what runner.yml http_egress
+// contains. Without these domains a JIT runner registers with GitHub but
+// cannot reach the broker / VSTOKEN endpoint and immediately goes offline
+// without picking up any queued job.
+//
+// MUST be kept in sync with the github_core ACL in
+// infra/squid/base.conf (the one-shot run.sh path). When either list
+// changes, update both files.
+var GitHubCoreDomains = []string{
+	".github.com",
+	"api.github.com",
+	".githubusercontent.com",
+	".actions.githubusercontent.com",
+	".objects.githubusercontent.com",
+	".github.githubassets.com",
+	".ghcr.io",
+	".pkg.github.com",
+	".pipelines.actions.githubusercontent.com",
+	".results-receiver.actions.githubusercontent.com",
+	".vstoken.actions.githubusercontent.com",
+}
+
 // sanitizeDomain returns the domain if it passes the domain regex, otherwise
 // returns an empty string. This prevents config injection via domains with
 // newlines or other metacharacters.
@@ -89,6 +112,27 @@ func RenderSquid(r *runneryml.Runner, p security.Policy) []byte {
 	}
 
 	b.WriteString("http_access deny rs_private_dst\n")
+
+	// GitHub Actions control-plane baseline (unconditional — every runner
+	// needs these domains to register, receive the VSTOKEN, stream logs, and
+	// report job results regardless of what runner.yml http_egress contains).
+	//
+	// Placed AFTER the private-IP deny (which is dst-IP based) so that a
+	// GitHub hostname that DNS-resolves to a private IP is still blocked by
+	// the dst-IP rule above before this allow is evaluated — maintaining the
+	// DNS-rebinding defense. GitHubCoreDomains are dstdomain ACLs, so Squid
+	// applies them on the CONNECT hostname, not the resolved IP; the ordering
+	// matters only for dst (IP) ACLs, not dstdomain ones, but we keep
+	// private-deny first as defence-in-depth.
+	//
+	// Sync: infra/squid/base.conf's github_core ACL must list the same
+	// domains (the one-shot run.sh path). See GitHubCoreDomains constant.
+	for _, d := range GitHubCoreDomains {
+		if clean := sanitizeDomain(d); clean != "" {
+			fmt.Fprintf(&b, "acl rs_github_core dstdomain %s\n", clean)
+		}
+	}
+	b.WriteString("http_access allow rs_github_core\n")
 
 	// Collect all permitted domains first, then emit the ACL and allow rule
 	// only when there are entries. An empty "acl allowed_domains dstdomain"

--- a/infra/orchestrator/internal/egress/squid_test.go
+++ b/infra/orchestrator/internal/egress/squid_test.go
@@ -326,6 +326,150 @@ func TestRenderSquid_AllowedPrivateCIDR_IPv6(t *testing.T) {
 	}
 }
 
+// ─── GitHub core baseline tests (issue #54, Fix #5) ────────────────────────
+
+// TestRenderSquid_GitHubCoreBaseline_EmptyHTTPEgress verifies that even when
+// runner.yml http_egress is empty, RenderSquid unconditionally emits every
+// GitHubCoreDomain as an rs_github_core ACL line AND the corresponding
+// http_access allow rule, and that they appear BEFORE http_access deny all.
+func TestRenderSquid_GitHubCoreBaseline_EmptyHTTPEgress(t *testing.T) {
+	r := &runneryml.Runner{} // no http_egress entries
+	policy := security.Defaults("strict")
+	policy.AllowWildcards = false
+
+	out := string(RenderSquid(r, policy))
+
+	// Every domain in the constant must appear.
+	for _, d := range GitHubCoreDomains {
+		acl := "acl rs_github_core dstdomain " + d
+		if !strings.Contains(out, acl) {
+			t.Errorf("GitHub core domain %q missing from squid config:\n%s", d, out)
+		}
+	}
+
+	// The allow rule must be present.
+	const allowLine = "http_access allow rs_github_core"
+	if !strings.Contains(out, allowLine) {
+		t.Fatalf("expected %q in squid config:\n%s", allowLine, out)
+	}
+
+	// The allow rule must come before deny all.
+	allowIdx := strings.Index(out, allowLine)
+	denyIdx := strings.Index(out, "http_access deny all")
+	if denyIdx < 0 {
+		t.Fatalf("http_access deny all missing from squid config:\n%s", out)
+	}
+	if allowIdx >= denyIdx {
+		t.Fatalf("rs_github_core allow (pos %d) must precede http_access deny all (pos %d):\n%s",
+			allowIdx, denyIdx, out)
+	}
+}
+
+// TestRenderSquid_GitHubCoreBaseline_PrivateDenyFirst verifies the ordering
+// invariant: the private-IP deny is emitted BEFORE the GitHub core allow.
+// The rs_private_dst deny is dst-IP based (resolved address); rs_github_core
+// is dstdomain (CONNECT hostname). Keeping private deny first ensures a
+// GitHub hostname that accidentally DNS-resolves to a private IP is caught
+// by the IP-based rule before the hostname-based allow fires.
+func TestRenderSquid_GitHubCoreBaseline_PrivateDenyFirst(t *testing.T) {
+	r := &runneryml.Runner{}
+	policy := security.Defaults("standard")
+
+	out := string(RenderSquid(r, policy))
+
+	privateDenyIdx := strings.Index(out, "http_access deny rs_private_dst")
+	githubAllowIdx := strings.Index(out, "http_access allow rs_github_core")
+
+	if privateDenyIdx < 0 {
+		t.Fatalf("http_access deny rs_private_dst missing:\n%s", out)
+	}
+	if githubAllowIdx < 0 {
+		t.Fatalf("http_access allow rs_github_core missing:\n%s", out)
+	}
+	if privateDenyIdx >= githubAllowIdx {
+		t.Fatalf("private-IP deny (pos %d) must precede github_core allow (pos %d):\n%s",
+			privateDenyIdx, githubAllowIdx, out)
+	}
+}
+
+// TestRenderSquid_GitHubCoreBaseline_WithProjectDomains verifies that when
+// runner.yml http_egress has project-specific domains too, both the
+// rs_github_core AND allowed_domains ACLs are emitted correctly.
+func TestRenderSquid_GitHubCoreBaseline_WithProjectDomains(t *testing.T) {
+	r := &runneryml.Runner{Egress: runneryml.Egress{AllowDomains: []string{"example.com"}}}
+	policy := security.Defaults("standard")
+
+	out := string(RenderSquid(r, policy))
+
+	// GitHub core baseline must be present.
+	if !strings.Contains(out, "acl rs_github_core dstdomain .github.com") {
+		t.Fatalf("rs_github_core baseline missing when project domains present:\n%s", out)
+	}
+	if !strings.Contains(out, "http_access allow rs_github_core") {
+		t.Fatalf("http_access allow rs_github_core missing:\n%s", out)
+	}
+
+	// Project-specific domains must also be present.
+	if !strings.Contains(out, "acl allowed_domains dstdomain .example.com") {
+		t.Fatalf("project domain missing from squid config:\n%s", out)
+	}
+	if !strings.Contains(out, "http_access allow allowed_domains") {
+		t.Fatalf("http_access allow allowed_domains missing:\n%s", out)
+	}
+
+	// Both allows must precede deny all.
+	denyIdx := strings.Index(out, "http_access deny all")
+	for _, allow := range []string{"http_access allow rs_github_core", "http_access allow allowed_domains"} {
+		idx := strings.Index(out, allow)
+		if idx < 0 {
+			t.Errorf("expected %q in output:\n%s", allow, out)
+			continue
+		}
+		if idx >= denyIdx {
+			t.Errorf("%q (pos %d) must precede deny all (pos %d):\n%s", allow, idx, denyIdx, out)
+		}
+	}
+}
+
+// TestRenderSquid_GitHubCoreConstant_MatchesBaseConf is a static consistency
+// check: GitHubCoreDomains must contain all 11 domains from base.conf's
+// github_core ACL. If a domain is added to base.conf and not here (or vice
+// versa) a runner in the compose backend will have a different allowlist than
+// one running through run.sh, creating a latent divergence.
+func TestRenderSquid_GitHubCoreConstant_MatchesBaseConf(t *testing.T) {
+	// These are the domains from infra/squid/base.conf's github_core ACL.
+	// Sync: if base.conf changes, update this test AND GitHubCoreDomains.
+	wantDomains := []string{
+		".github.com",
+		"api.github.com",
+		".githubusercontent.com",
+		".actions.githubusercontent.com",
+		".objects.githubusercontent.com",
+		".github.githubassets.com",
+		".ghcr.io",
+		".pkg.github.com",
+		".pipelines.actions.githubusercontent.com",
+		".results-receiver.actions.githubusercontent.com",
+		".vstoken.actions.githubusercontent.com",
+	}
+
+	inConst := map[string]bool{}
+	for _, d := range GitHubCoreDomains {
+		inConst[d] = true
+	}
+
+	for _, want := range wantDomains {
+		if !inConst[want] {
+			t.Errorf("domain %q is in base.conf github_core but missing from GitHubCoreDomains", want)
+		}
+	}
+
+	if len(GitHubCoreDomains) != len(wantDomains) {
+		t.Errorf("GitHubCoreDomains has %d entries, base.conf github_core has %d; they must match",
+			len(GitHubCoreDomains), len(wantDomains))
+	}
+}
+
 // TestRenderSquid_AllowedPrivateCIDR_MalformedSkipped verifies that a
 // *net.IPNet whose String() returns a non-canonical value (e.g. "<nil>") is
 // silently skipped rather than injected into the squid config. This exercises

--- a/infra/orchestrator/internal/orchestrator/fakedeps_test.go
+++ b/infra/orchestrator/internal/orchestrator/fakedeps_test.go
@@ -217,6 +217,10 @@ func (f *fakeDockerClient) ListContainersForScope(ctx context.Context, scope str
 	return nil, nil
 }
 
+func (f *fakeDockerClient) ListNetworksForScope(ctx context.Context, scope string) ([]docker.Network, error) {
+	return nil, nil
+}
+
 // ------------- in-memory emitter + fake breakers/buckets ------------------
 
 type fakeBreakers struct {

--- a/infra/socket-proxy/cmd/socket-proxy/main.go
+++ b/infra/socket-proxy/cmd/socket-proxy/main.go
@@ -26,9 +26,16 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	allow, err := imageallow.Load(cfg.AllowedImagesFile)
+	// LoadWithExtra merges the baked allowlist with an optional operator-supplied
+	// file (RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE). The extra file solves the
+	// release bootstrap problem: newly-published image digests can't be baked
+	// into the socket-proxy image before that image exists (#54 fix 3).
+	allow, err := imageallow.LoadWithExtra(cfg.AllowedImagesFile, cfg.AllowedImagesExtraFile)
 	if err != nil {
 		return err
+	}
+	if cfg.AllowedImagesExtraFile != "" {
+		log.Printf("socket-proxy: extra allowlist=%s", cfg.AllowedImagesExtraFile)
 	}
 	log.Printf("socket-proxy: listening on %s (image-allowlist=%d entries)", cfg.ListenAddr, allow.Size())
 

--- a/infra/socket-proxy/internal/config/config.go
+++ b/infra/socket-proxy/internal/config/config.go
@@ -14,7 +14,18 @@ import (
 type Config struct {
 	DockerSock        string // path to docker.sock on the host (bind-mounted)
 	ListenAddr        string // tcp listen address (default :2375)
-	AllowedImagesFile string // path to digest allowlist file
+	AllowedImagesFile string // path to digest allowlist file (baked into image)
+	// AllowedImagesExtraFile is an optional operator-supplied allowlist that is
+	// merged with AllowedImagesFile at startup. It follows the same format (one
+	// digest reference per line). If the path is non-empty but the file does not
+	// exist the socket-proxy starts normally with only the baked allowlist.
+	//
+	// This solves the release bootstrap problem (#54 fix 3): at release time the
+	// published proxy/runner image digests are not yet known, so they cannot be
+	// baked into the allowlist. Operators can mount a file with the release-specific
+	// digests via a volume in compose.scope.yml and set RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE
+	// to its path, without modifying or rebuilding the socket-proxy image itself.
+	AllowedImagesExtraFile string
 
 	TLSMode         string // "plaintext" (default) | "mtls"
 	TLSCertFile     string // server certificate (PEM)
@@ -32,9 +43,10 @@ const (
 
 func FromEnv() (Config, error) {
 	c := Config{
-		DockerSock:        os.Getenv("RUNSECURE_DOCKER_SOCK"),
-		ListenAddr:        envOr("RUNSECURE_LISTEN_ADDR", defaultListen),
-		AllowedImagesFile: envOr("RUNSECURE_ALLOWED_IMAGES_FILE", defaultAllowedImages),
+		DockerSock:             os.Getenv("RUNSECURE_DOCKER_SOCK"),
+		ListenAddr:             envOr("RUNSECURE_LISTEN_ADDR", defaultListen),
+		AllowedImagesFile:      envOr("RUNSECURE_ALLOWED_IMAGES_FILE", defaultAllowedImages),
+		AllowedImagesExtraFile: os.Getenv("RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE"),
 
 		TLSMode:         envOr("RUNSECURE_SP_TLS_MODE", defaultTLSMode),
 		TLSCertFile:     os.Getenv("RUNSECURE_SP_TLS_CERT"),

--- a/infra/socket-proxy/internal/config/config_test.go
+++ b/infra/socket-proxy/internal/config/config_test.go
@@ -103,3 +103,25 @@ func TestFromEnv_TLS_InvalidMode(t *testing.T) {
 	_, err := FromEnv()
 	require.ErrorContains(t, err, "invalid TLS mode")
 }
+
+// ─── AllowedImagesExtraFile tests (issue #54 fix 3) ──────────────────────────
+
+// TestFromEnv_ExtraImagesFile_Default verifies that AllowedImagesExtraFile is
+// empty string when RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE is not set.
+func TestFromEnv_ExtraImagesFile_Default(t *testing.T) {
+	t.Setenv("RUNSECURE_DOCKER_SOCK", "/var/run/docker.sock")
+	t.Setenv("RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE", "")
+	c, err := FromEnv()
+	require.NoError(t, err)
+	require.Empty(t, c.AllowedImagesExtraFile)
+}
+
+// TestFromEnv_ExtraImagesFile_Set verifies that RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE
+// is forwarded into the Config struct.
+func TestFromEnv_ExtraImagesFile_Set(t *testing.T) {
+	t.Setenv("RUNSECURE_DOCKER_SOCK", "/var/run/docker.sock")
+	t.Setenv("RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE", "/run/secrets/extra-images.txt")
+	c, err := FromEnv()
+	require.NoError(t, err)
+	require.Equal(t, "/run/secrets/extra-images.txt", c.AllowedImagesExtraFile)
+}

--- a/infra/socket-proxy/internal/imageallow/imageallow.go
+++ b/infra/socket-proxy/internal/imageallow/imageallow.go
@@ -31,6 +31,44 @@ func Load(path string) (*Allowlist, error) {
 	return parse(f, path)
 }
 
+// LoadWithExtra loads the primary allowlist from path, then merges entries from
+// extraPath if it is non-empty and the file exists. This allows operators to
+// supply release-specific digests at runtime without rebuilding the
+// socket-proxy image — addressing the bootstrap problem where a newly-released
+// proxy/runner image digest cannot be baked into the allowlist at release time
+// because the image is not yet published when the release tag is cut (#54 fix 3).
+//
+// extraPath must follow the same format as path. Errors loading extraPath
+// are returned; a missing file (os.IsNotExist) is silently ignored so the
+// operator does not need to supply the file on every deployment.
+func LoadWithExtra(path, extraPath string) (*Allowlist, error) {
+	base, err := Load(path)
+	if err != nil {
+		return nil, err
+	}
+	if extraPath == "" {
+		return base, nil
+	}
+	ef, err := os.Open(extraPath)
+	if os.IsNotExist(err) {
+		// Extra file absent — not an error. Operator didn't supply one.
+		return base, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("imageallow: open extra %s: %w", extraPath, err)
+	}
+	defer ef.Close()
+	extra, err := parse(ef, extraPath)
+	if err != nil {
+		return nil, err
+	}
+	// Merge: add all extra entries into base.
+	for ref := range extra.allowed {
+		base.allowed[ref] = struct{}{}
+	}
+	return base, nil
+}
+
 // parse scans r line-by-line, building an Allowlist. label is used in error
 // messages (typically the file path). Extracted so tests can inject a reader
 // that returns mid-stream I/O errors to exercise the scanner.Err() branch.

--- a/infra/socket-proxy/internal/imageallow/imageallow_test.go
+++ b/infra/socket-proxy/internal/imageallow/imageallow_test.go
@@ -118,3 +118,106 @@ func TestParse_AllowsAndDenies(t *testing.T) {
 	require.True(t, a.Allows("ghcr.io/img@sha256:deadbeef"))
 	require.False(t, a.Allows("ghcr.io/img:latest"))
 }
+
+// ─── LoadWithExtra tests (issue #54 fix 3) ────────────────────────────────────
+
+// TestLoadWithExtra_MergesBothFiles verifies that entries from both the base
+// and extra files are present in the merged allowlist.
+func TestLoadWithExtra_MergesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	extraPath := filepath.Join(dir, "extra.txt")
+
+	require.NoError(t, os.WriteFile(basePath, []byte(
+		"ghcr.io/runsecure/proxy@sha256:aabbcc\n"+
+			"ghcr.io/runsecure/runner-node@sha256:ddeeff\n",
+	), 0o644))
+	require.NoError(t, os.WriteFile(extraPath, []byte(
+		"# release-specific digests\n"+
+			"ghcr.io/runsecure/proxy@sha256:112233\n",
+	), 0o644))
+
+	a, err := LoadWithExtra(basePath, extraPath)
+	require.NoError(t, err)
+	require.Equal(t, 3, a.Size())
+	require.True(t, a.Allows("ghcr.io/runsecure/proxy@sha256:aabbcc"))
+	require.True(t, a.Allows("ghcr.io/runsecure/runner-node@sha256:ddeeff"))
+	require.True(t, a.Allows("ghcr.io/runsecure/proxy@sha256:112233"))
+}
+
+// TestLoadWithExtra_EmptyExtraPath_ReturnsBase verifies that an empty extraPath
+// behaves identically to Load (no merge attempt, no error).
+func TestLoadWithExtra_EmptyExtraPath_ReturnsBase(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	require.NoError(t, os.WriteFile(basePath, []byte(
+		"ghcr.io/runsecure/proxy@sha256:aabbcc\n",
+	), 0o644))
+
+	a, err := LoadWithExtra(basePath, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, a.Size())
+	require.True(t, a.Allows("ghcr.io/runsecure/proxy@sha256:aabbcc"))
+}
+
+// TestLoadWithExtra_MissingExtraFile_NotAnError verifies that when extraPath is
+// set but the file does not exist, LoadWithExtra succeeds with only the base
+// entries. Operators may set RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE before the
+// file is created; the socket-proxy must still start.
+func TestLoadWithExtra_MissingExtraFile_NotAnError(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	require.NoError(t, os.WriteFile(basePath, []byte(
+		"ghcr.io/runsecure/proxy@sha256:aabbcc\n",
+	), 0o644))
+
+	a, err := LoadWithExtra(basePath, filepath.Join(dir, "nonexistent.txt"))
+	require.NoError(t, err)
+	require.Equal(t, 1, a.Size())
+}
+
+// TestLoadWithExtra_ExtraFileHasTagEntry_Errors verifies that a tag-only entry
+// in the extra file is rejected (same format requirement as the base file).
+func TestLoadWithExtra_ExtraFileHasTagEntry_Errors(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	extraPath := filepath.Join(dir, "extra.txt")
+	require.NoError(t, os.WriteFile(basePath, []byte(
+		"ghcr.io/runsecure/proxy@sha256:aabbcc\n",
+	), 0o644))
+	require.NoError(t, os.WriteFile(extraPath, []byte(
+		"ghcr.io/runsecure/proxy:latest\n",
+	), 0o644))
+
+	_, err := LoadWithExtra(basePath, extraPath)
+	require.ErrorContains(t, err, "@sha256:")
+}
+
+// TestLoadWithExtra_BaseFileMissing_Errors verifies that an error loading the
+// base allowlist propagates (extra file is irrelevant when base fails).
+func TestLoadWithExtra_BaseFileMissing_Errors(t *testing.T) {
+	_, err := LoadWithExtra("/nonexistent/base.txt", "")
+	require.Error(t, err)
+}
+
+// TestLoadWithExtra_ExtraFileUnreadable_Errors covers the branch in LoadWithExtra
+// where os.Open(extraPath) fails with a non-IsNotExist error (e.g. permission denied).
+// Without this test, the "imageallow: open extra %s" error message is unreachable.
+func TestLoadWithExtra_ExtraFileUnreadable_Errors(t *testing.T) {
+	if os.Getuid() == 0 {
+		// Root bypasses permission checks; skip rather than create a fragile workaround.
+		t.Skip("cannot test permission denied as root")
+	}
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	extraPath := filepath.Join(dir, "extra.txt")
+	require.NoError(t, os.WriteFile(basePath, []byte(
+		"ghcr.io/runsecure/proxy@sha256:aabbcc\n",
+	), 0o644))
+	// Create the extra file then chmod 000 so it exists but is unreadable.
+	require.NoError(t, os.WriteFile(extraPath, []byte(""), 0o000))
+	defer os.Chmod(extraPath, 0o644) // restore so TempDir cleanup can remove it
+
+	_, err := LoadWithExtra(basePath, extraPath)
+	require.ErrorContains(t, err, "imageallow: open extra")
+}

--- a/infra/socket-proxy/internal/proxy/routes.go
+++ b/infra/socket-proxy/internal/proxy/routes.go
@@ -26,6 +26,11 @@ var allowedRoutes = []struct {
 	{"POST", regexp.MustCompile(`^/containers/create$`)},
 	{"POST", regexp.MustCompile(`^/containers/[^/]+/start$`)},
 	{"DELETE", regexp.MustCompile(`^/containers/[^/]+$`)},
+	// GET /networks is allowed for cold-start orphan cleanup: the orchestrator
+	// lists networks with a runsecure.scope label filter on restart to remove
+	// per-spawn networks left from a previous run. The route is read-only and
+	// narrowly used; write access (create/delete) is unchanged (#54 fix 4).
+	{"GET", regexp.MustCompile(`^/networks$`)},
 	{"POST", regexp.MustCompile(`^/networks/create$`)},
 	{"DELETE", regexp.MustCompile(`^/networks/[^/]+$`)},
 	// POST /networks/{id}/connect is intentionally absent: the orchestrator

--- a/infra/socket-proxy/internal/proxy/routes_test.go
+++ b/infra/socket-proxy/internal/proxy/routes_test.go
@@ -24,6 +24,10 @@ func TestRouteAllowed_ContainersAndNetworks(t *testing.T) {
 		{http.MethodDelete, "/v1.43/networks/xyz", true},
 		{http.MethodGet, "/v1.44/info", true},
 
+		// GET /networks is allowed for cold-start orphan cleanup (#54 fix 4).
+		{http.MethodGet, "/v1.43/networks", true},
+		{http.MethodGet, "/v1.44/networks", true},
+
 		// blocked
 		{http.MethodPost, "/v1.43/networks/xyz/connect", false}, // removed: unused + egress bypass risk
 		{http.MethodPost, "/v1.43/containers/abc/exec", false},

--- a/infra/squid/base.conf
+++ b/infra/squid/base.conf
@@ -61,6 +61,10 @@ acl rs_private_dst dst fc00::/7
 http_access deny rs_private_dst
 
 # --- Allowed domains: GitHub core ---
+# SYNC: this domain list MUST match GitHubCoreDomains in
+# infra/orchestrator/internal/egress/squid.go (the compose-backend path).
+# The one-shot run.sh path reads THIS file; the long-running orchestrator
+# uses the Go constant. Any change here must be mirrored there and vice versa.
 acl github_core dstdomain .github.com
 acl github_core dstdomain api.github.com
 acl github_core dstdomain .githubusercontent.com

--- a/tests/validation/test-compose-hardening.sh
+++ b/tests/validation/test-compose-hardening.sh
@@ -145,6 +145,57 @@ assert_in_service "${SCOPE_COMPOSE}" "socket-proxy" \
     'RUNSECURE_EGRESS_NETWORK' \
     "T8: socket-proxy service has RUNSECURE_EGRESS_NETWORK env"
 
+# --- Issue #54 fix 1: orch-egress must have tmpfs for squid runtime dirs ----
+# Without these, squid FATALs with "Read-only file system" on pidfile write
+# when running under read_only: true (#54 fix 1).
+# The orch-egress service block in compose.scope.yml lists tmpfs entries as
+#   "- /var/run/squid:..."
+# so we check for each dir in the file directly (they only appear in the
+# orch-egress tmpfs block; the orchestrator's tmpfs only has /tmp).
+EGRESS_RANGE=$(_service_range "${SCOPE_COMPOSE}" "orch-egress")
+if [[ -n "$EGRESS_RANGE" ]]; then
+    e_start="${EGRESS_RANGE%:*}"; e_end="${EGRESS_RANGE#*:}"
+    for squid_dir in /var/run/squid /var/log/squid /var/spool/squid; do
+        if sed -n "${e_start},${e_end}p" "${SCOPE_COMPOSE}" | grep -qF "$squid_dir"; then
+            pass "Issue54-F1: orch-egress has tmpfs for $squid_dir"
+        else
+            fail "Issue54-F1: orch-egress must have tmpfs mount for $squid_dir (squid pidfile/log write fails without it)"
+        fi
+    done
+else
+    fail "Issue54-F1: orch-egress service not found in ${SCOPE_COMPOSE}"
+fi
+
+# --- Issue #54 fix 2: orch-egress must be attached to spawn-egress ----------
+# Without this, compose never creates the spawn-egress network and every
+# per-spawn proxy attach fails with 404 "network not found" (#54 fix 2).
+assert_in_service "${SCOPE_COMPOSE}" "orch-egress" \
+    'spawn-egress' \
+    "Issue54-F2: orch-egress is attached to spawn-egress (ensures compose creates the network)"
+
+# --- Issue #54 fix 2: orchestrator must NOT be attached to spawn-egress ----
+# Verify the orchestrator is confined to orch-internal; attaching it to
+# spawn-egress would break the network-isolation model.
+# We check the networks: key of the orchestrator service specifically —
+# RUNSECURE_EGRESS_NETWORK env var contains "spawn-egress" in its value
+# which is expected and correct; we must not match that.
+# The orchestrator service uses "networks: [orch-internal]" (inline list)
+# so we look for the inline list form, not a networks block with spawn-egress.
+ORCH_RANGE=$(_service_range "${SCOPE_COMPOSE}" "orchestrator")
+if [[ -n "$ORCH_RANGE" ]]; then
+    o_start="${ORCH_RANGE%:*}"; o_end="${ORCH_RANGE#*:}"
+    # Extract only lines under the "networks:" key of the orchestrator block
+    # (stop at the next unindented key). Filter out environment variable values
+    # that happen to contain "spawn-egress" as a string value.
+    if sed -n "${o_start},${o_end}p" "${SCOPE_COMPOSE}" \
+           | awk '/^    networks:/{p=1;next} p && /^    [a-zA-Z]/{exit} p' \
+           | grep -q 'spawn-egress'; then
+        fail "Issue54-F2: orchestrator must NOT be attached to spawn-egress (isolation breach)"
+    else
+        pass "Issue54-F2: orchestrator is not attached to spawn-egress (isolation preserved)"
+    fi
+fi
+
 # --- Print results -----------------------------------------------------------
 echo ""
 echo "=== Compose Hardening Assertions ==="


### PR DESCRIPTION
Fixes the five blockers in #54 that make the **Compose-backend orchestrator** non-functional from a clean checkout on macOS/Colima. Root-caused with systematic-debugging before fixing.

## #5 (critical) — runners register then go offline, no job runs
**Root cause:** the orchestrator's per-spawn `RenderSquid` allowlist contained **only** the project's `runner.yml` `http_egress` + the private-IP deny — **none** of the GitHub Actions control-plane domains the runner agent must reach (`api.github.com`, `.actions.githubusercontent.com`, `.pipelines.actions.githubusercontent.com`, `.vstoken…`, `.results-receiver…`, `.githubusercontent.com`, …). The working `run.sh` path baseline-allows these via `base.conf`'s `github_core` ACL, which is why `run.sh` works and the orchestrator never did. **Fix:** added a `GitHubCoreDomains` baseline (matching `base.conf`, with a sync-guard comment in both files), always emitted in `RenderSquid` after the private-IP deny and before `deny all`. 4 regression tests; `internal/egress` 100%.

## #1 — orch-egress crash-loops under `read_only`
Squid FATALs writing its pidfile. **Fix:** `user: "1001:1001"` + tmpfs for `/var/run/squid`, `/var/log/squid`, `/var/spool/squid` (uid/gid 1001). `read_only` kept. +compose-hardening assertions.

## #2 — `spawn-egress` network never created
Compose only creates networks a service references. **Fix:** attach `orch-egress` to `spawn-egress` so compose creates it (runners stay on per-spawn internal-only networks; isolation unchanged). +assertions.

## #4 — per-spawn network leak → address-pool exhaustion
**Fix:** `ListNetworksForScope` (read-only `GET /networks`, added to the socket-proxy allowlist) + cold-start orphan-network cleanup. `internal/docker` 100%.

## #3 — `allowed-images.txt` digest can't be baked for the same release
**Fix:** `imageallow.LoadWithExtra` merges an operator-supplied allowlist at runtime via `RUNSECURE_ALLOWED_IMAGES_EXTRA_FILE` (digest-pinning preserved; no tag refs). `imageallow` 100%.

## Verification
Both Go modules green; changed packages ≥99% (egress/docker/imageallow/config 100%, orchestrator/proxy 99.3%); compose-hardening + go-coverage gates pass.

**Live verification still recommended:** #5's end-to-end (runner comes online + runs a job on a Colima host) should be confirmed with a real bring-up against a repo that has queued jobs — the code root cause is addressed and matches the proven `run.sh` baseline, but the empty-access.log symptom was observed on a live host and deserves a live re-test. Happy to drive that bring-up.

Closes #54.