### PR TITLE
chore(chart): track 2.1.2 (appVersion + image digests)

### DIFF
--- a/charts/runsecure-orchestrator/Chart.yaml
+++ b/charts/runsecure-orchestrator/Chart.yaml
@@ -6,8 +6,8 @@ description: >
   with namespace-scoped RBAC, default-deny NetworkPolicies, and Pod Security
   Standards "Restricted" on every namespace.
 type: application
-version: 0.1.0
-appVersion: "2.1.0"
+version: 0.1.1
+appVersion: "2.1.2"
 kubeVersion: ">=1.26.0"
 keywords:
   - github-actions

--- a/charts/runsecure-orchestrator/values.yaml
+++ b/charts/runsecure-orchestrator/values.yaml
@@ -11,18 +11,18 @@
 image:
   orchestrator:
     repository: ghcr.io/andend-collective/runsecure/orchestrator
-    tag: "2.1.0"
-    digest: "sha256:5f88ad8608510c089dc5011e3a2fbe014f2e6256cdcfdfda938c3b676cb969ab"
+    tag: "2.1.2"
+    digest: "sha256:cd5918ac59cc2b8261afecc1e6b43e3fcb14cd8b60329fc4088d99832c0155c5"
     pullPolicy: Always
   proxy:
     repository: ghcr.io/andend-collective/runsecure/proxy
-    tag: "2.1.0"
-    digest: "sha256:8d6eab73932cd6e13cc1f25bfa250ecb0aad6cc891754018d1be9266a0f11c32"
+    tag: "2.1.2"
+    digest: "sha256:653a28372741957135874c517b7a743a95ff27f7a7c3ffa293fd5cf2cf7dc3b0"
     pullPolicy: Always
   socketProxy:
     repository: ghcr.io/andend-collective/runsecure/socket-proxy
-    tag: "2.1.0"
-    digest: "sha256:44b5d07f0ef7f2c7e6121110a392d23288ec7676ee106779c32af98d67d5d866"
+    tag: "2.1.2"
+    digest: "sha256:4a7af59d856a98a1f4515d67c6eb881f604bf01bd834ccd5bb8f2d91cfdc5778"
     pullPolicy: Always
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates the Helm chart to the just-promoted **2.1.2** release: appVersion 2.1.0→2.1.2, chart version 0.1.0→0.1.1, and the three image `tag`/`digest` pins to the real 2.1.2 GHCR manifests (orchestrator `@cd5918ac…`, proxy `@653a2837…`, socket-proxy `@4a7af59d…`). helm lint + kubeconform + CIS/PSS assertions pass.